### PR TITLE
feat(users): add dedicated role change workflow (Resolves #4)

### DIFF
--- a/client/src/components/CreateUserModal.tsx
+++ b/client/src/components/CreateUserModal.tsx
@@ -30,6 +30,22 @@ interface UserProfile {
   };
 }
 
+type UserFormData = {
+  login: string;
+  password?: string;
+  role: Role;
+  email: string;
+  firstName: string;
+  lastName: string;
+  middleName: string;
+  phone: string;
+  groupId: string;
+  recordBookNumber: string;
+  year: number;
+  departmentId: string;
+  position: string;
+};
+
 interface Props {
   isOpen: boolean;
   onClose: () => void;
@@ -37,38 +53,54 @@ interface Props {
   userToEdit?: UserProfile | null;
 }
 
+function getReferenceId(value: ReferenceItem | string | undefined): string {
+  if (!value) return '';
+  if (typeof value === 'string') return value;
+  return value.id || value._id || '';
+}
+
+function buildInitialFormData(userToEdit?: UserProfile | null): UserFormData {
+  if (!userToEdit) {
+    return {
+      login: '',
+      password: '',
+      role: Role.STUDENT,
+      email: '',
+      firstName: '',
+      lastName: '',
+      middleName: '',
+      phone: '',
+      groupId: '',
+      recordBookNumber: '',
+      year: 1,
+      departmentId: '',
+      position: '',
+    };
+  }
+
+  return {
+    login: userToEdit.login || '',
+    password: '',
+    role: userToEdit.role || Role.STUDENT,
+    email: userToEdit.email || '',
+    firstName: userToEdit.firstName || '',
+    lastName: userToEdit.lastName || '',
+    middleName: userToEdit.middleName || '',
+    phone: userToEdit.phone || '',
+    groupId: getReferenceId(userToEdit.studentProfile?.group),
+    recordBookNumber: userToEdit.studentProfile?.recordBookNumber || '',
+    year: userToEdit.studentProfile?.year || 1,
+    departmentId: getReferenceId(userToEdit.teacherProfile?.department),
+    position: userToEdit.teacherProfile?.position || '',
+  };
+}
+
 export default function CreateUserModal({ isOpen, onClose, onSuccess, userToEdit }: Props) {
   const { t } = useTranslation();
 
-  const [formData, setFormData] = useState<{
-    login: string;
-    password?: string;
-    role: Role;
-    email: string;
-    firstName: string;
-    lastName: string;
-    middleName: string;
-    phone: string;
-    groupId: string;
-    recordBookNumber: string;
-    year: number;
-    departmentId: string;
-    position: string;
-  }>({
-    login: '',
-    password: '',
-    role: Role.STUDENT,
-    email: '',
-    firstName: '',
-    lastName: '',
-    middleName: '',
-    phone: '',
-    groupId: '',
-    recordBookNumber: '',
-    year: 1,
-    departmentId: '',
-    position: '',
-  });
+  const [formData, setFormData] = useState<UserFormData>(
+    buildInitialFormData(),
+  );
 
   const [groups, setGroups] = useState<ReferenceItem[]>([]);
   const [departments, setDepartments] = useState<ReferenceItem[]>([]);
@@ -87,42 +119,7 @@ export default function CreateUserModal({ isOpen, onClose, onSuccess, userToEdit
 
   useEffect(() => {
     if (isOpen) {
-      if (userToEdit) {
-        const studentGroup = userToEdit.studentProfile?.group;
-        const teacherDept = userToEdit.teacherProfile?.department;
-
-        setFormData({
-          login: userToEdit.login || '',
-          password: '',
-          role: userToEdit.role || Role.STUDENT,
-          email: userToEdit.email || '',
-          firstName: userToEdit.firstName || '',
-          lastName: userToEdit.lastName || '',
-          middleName: userToEdit.middleName || '',
-          phone: userToEdit.phone || '',
-          groupId: typeof studentGroup === 'object' ? studentGroup?.id || '' : studentGroup || '',
-          recordBookNumber: userToEdit.studentProfile?.recordBookNumber || '',
-          year: userToEdit.studentProfile?.year || 1,
-          departmentId: typeof teacherDept === 'object' ? teacherDept?.id || '' : teacherDept || '',
-          position: userToEdit.teacherProfile?.position || '',
-        });
-      } else {
-        setFormData({
-          login: '',
-          password: '',
-          role: Role.STUDENT,
-          email: '',
-          firstName: '',
-          lastName: '',
-          middleName: '',
-          phone: '',
-          groupId: '',
-          recordBookNumber: '',
-          year: 1,
-          departmentId: '',
-          position: '',
-        });
-      }
+      setFormData(buildInitialFormData(userToEdit));
     }
   }, [isOpen, userToEdit]);
 
@@ -142,6 +139,42 @@ export default function CreateUserModal({ isOpen, onClose, onSuccess, userToEdit
     }
   };
 
+  const buildBasePayload = () => {
+    const payload: Record<string, unknown> = {
+      login: formData.login.trim(),
+      email: formData.email.trim(),
+      firstName: formData.firstName.trim(),
+      lastName: formData.lastName.trim(),
+      middleName: formData.middleName.trim(),
+      phone: formData.phone.trim(),
+    };
+
+    if (formData.password) {
+      payload.password = formData.password;
+    }
+
+    return payload;
+  };
+
+  const buildRolePayload = () => {
+    const payload: Record<string, unknown> = {
+      role: formData.role,
+    };
+
+    if (formData.role === Role.STUDENT) {
+      payload.groupId = formData.groupId;
+      payload.recordBookNumber = formData.recordBookNumber.trim();
+      payload.year = formData.year;
+    }
+
+    if (formData.role === Role.TEACHER) {
+      payload.departmentId = formData.departmentId;
+      payload.position = formData.position.trim();
+    }
+
+    return payload;
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError('');
@@ -157,36 +190,31 @@ export default function CreateUserModal({ isOpen, onClose, onSuccess, userToEdit
     }
 
     try {
-      const payload: Record<string, unknown> = { ...formData };
+      const basePayload = buildBasePayload();
+      const rolePayload = buildRolePayload();
 
-      if (userToEdit && !payload.password) {
-        Reflect.deleteProperty(payload, 'password');
-        await api.patch(`/users/${userToEdit.id}`, payload);
-      } else {
-        if (userToEdit) {
-          await api.patch(`/users/${userToEdit.id}`, payload);
+      if (userToEdit) {
+        const roleChanged = userToEdit.role !== formData.role;
+
+        if (roleChanged) {
+          await api.patch(`/users/${userToEdit.id}`, basePayload);
+          await api.patch(`/users/${userToEdit.id}/role`, rolePayload);
         } else {
-          await api.post('/users', payload);
+          await api.patch(`/users/${userToEdit.id}`, {
+            ...basePayload,
+            ...rolePayload,
+          });
         }
+      } else {
+        await api.post('/users', {
+          ...basePayload,
+          ...rolePayload,
+        });
       }
 
       onSuccess();
       onClose();
-      setFormData({
-        login: '',
-        password: '',
-        role: Role.STUDENT,
-        email: '',
-        firstName: '',
-        lastName: '',
-        middleName: '',
-        phone: '',
-        groupId: '',
-        recordBookNumber: '',
-        year: 1,
-        departmentId: '',
-        position: '',
-      });
+      setFormData(buildInitialFormData());
     } catch (err: unknown) {
       const errorObj = err as { response?: { data?: { message?: string } } };
       setError(errorObj.response?.data?.message || 'Помилка при створенні користувача');

--- a/server/src/users/dto/change-user-role.dto.ts
+++ b/server/src/users/dto/change-user-role.dto.ts
@@ -1,0 +1,62 @@
+import { Type } from 'class-transformer';
+import {
+  IsEnum,
+  IsInt,
+  IsMongoId,
+  IsNotEmpty,
+  IsString,
+  Min,
+  ValidateIf,
+} from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Role } from '../../common/types/roles.enum';
+import { ExistsInDatabase } from '../../common/validators/exists-in-database.validator';
+import { Department, Group } from '../../references/schemas';
+
+export class ChangeUserRoleDto {
+  @ApiProperty({ enum: Role })
+  @IsEnum(Role)
+  role: Role;
+
+  @ApiPropertyOptional({
+    description: 'Required when changing the user role to student',
+  })
+  @ValidateIf((dto: ChangeUserRoleDto) => dto.role === Role.STUDENT)
+  @IsMongoId()
+  @ExistsInDatabase(Group.name)
+  groupId?: string;
+
+  @ApiPropertyOptional({
+    description: 'Required when changing the user role to student',
+  })
+  @ValidateIf((dto: ChangeUserRoleDto) => dto.role === Role.STUDENT)
+  @IsString()
+  @IsNotEmpty()
+  recordBookNumber?: string;
+
+  @ApiPropertyOptional({
+    description: 'Required when changing the user role to student',
+    minimum: 1,
+  })
+  @ValidateIf((dto: ChangeUserRoleDto) => dto.role === Role.STUDENT)
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  year?: number;
+
+  @ApiPropertyOptional({
+    description: 'Required when changing the user role to teacher',
+  })
+  @ValidateIf((dto: ChangeUserRoleDto) => dto.role === Role.TEACHER)
+  @IsMongoId()
+  @ExistsInDatabase(Department.name)
+  departmentId?: string;
+
+  @ApiPropertyOptional({
+    description: 'Required when changing the user role to teacher',
+  })
+  @ValidateIf((dto: ChangeUserRoleDto) => dto.role === Role.TEACHER)
+  @IsString()
+  @IsNotEmpty()
+  position?: string;
+}

--- a/server/src/users/users.controller.ts
+++ b/server/src/users/users.controller.ts
@@ -7,16 +7,24 @@ import {
   Param,
   Query,
   UseGuards,
+  Req,
 } from '@nestjs/common';
-import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { RolesGuard, Roles } from '../auth/roles.guard';
 import { UsersService } from './users.service';
 import { Role } from '../common/types/roles.enum';
+import { AuthenticatedRequest } from '../common/types/authenticated-request';
 import { PaginatedDto } from '../common/dto/paginated.dto';
 import { UserDto } from './dto/user.dto';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
+import { ChangeUserRoleDto } from './dto/change-user-role.dto';
 import { UserQueryDto } from './dto/user-query.dto';
 import { UserSearchQueryDto } from './dto/user-search-query.dto';
 import { ApiPaginatedResponse } from '../common/swagger/api-paginated.response';
@@ -36,8 +44,27 @@ export class UsersController {
 
   @Patch(':id')
   @Roles(Role.ADMIN)
-  update(@Param('id') id: string, @Body() updateUserDto: UpdateUserDto) {
-    return this.usersService.update(id, updateUserDto);
+  update(
+    @Param('id') id: string,
+    @Body() updateUserDto: UpdateUserDto,
+    @Req() req: AuthenticatedRequest,
+  ) {
+    return this.usersService.update(id, updateUserDto, req.user.sub);
+  }
+
+  @Patch(':id/role')
+  @Roles(Role.ADMIN)
+  @ApiOperation({ summary: 'Change user role' })
+  @ApiResponse({ status: 200, type: UserDto })
+  @ApiResponse({ status: 400, description: 'Invalid role transition payload' })
+  @ApiResponse({ status: 403, description: 'Cannot change own role' })
+  @ApiResponse({ status: 404, description: 'User not found' })
+  changeRole(
+    @Param('id') id: string,
+    @Body() changeUserRoleDto: ChangeUserRoleDto,
+    @Req() req: AuthenticatedRequest,
+  ) {
+    return this.usersService.changeRole(id, changeUserRoleDto, req.user.sub);
   }
 
   @Patch(':id/block')

--- a/server/src/users/users.service.spec.ts
+++ b/server/src/users/users.service.spec.ts
@@ -1,0 +1,259 @@
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+} from '@nestjs/common';
+import { Types } from 'mongoose';
+import { Role } from '../common/types/roles.enum';
+import { ChangeUserRoleDto } from './dto/change-user-role.dto';
+import { UsersService } from './users.service';
+
+type ModelMock = {
+  findById: jest.Mock;
+  findByIdAndUpdate: jest.Mock;
+  findOne: jest.Mock;
+  countDocuments: jest.Mock;
+};
+
+function objectId(): string {
+  return new Types.ObjectId().toHexString();
+}
+
+function query<T>(value: T) {
+  return {
+    select: jest.fn().mockReturnThis(),
+    lean: jest.fn().mockReturnThis(),
+    exec: jest.fn().mockResolvedValue(value),
+  };
+}
+
+function userResponse(overrides: Record<string, unknown> = {}) {
+  return {
+    _id: objectId(),
+    login: 'user1',
+    email: 'user1@maup.com.ua',
+    role: Role.TEACHER,
+    firstName: 'Іван',
+    lastName: 'Петренко',
+    status: 'active',
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-01-02T00:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+describe('UsersService', () => {
+  let service: UsersService;
+  let model: ModelMock;
+  let removeAllRefreshTokenHashesSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    model = {
+      findById: jest.fn(),
+      findByIdAndUpdate: jest.fn(),
+      findOne: jest.fn(),
+      countDocuments: jest.fn(),
+    };
+
+    service = new UsersService(model as never);
+    removeAllRefreshTokenHashesSpy = jest
+      .spyOn(service, 'removeAllRefreshTokenHashes')
+      .mockResolvedValue(undefined);
+  });
+
+  it('changes a student to teacher, clears the student profile and resets refresh sessions', async () => {
+    const userId = objectId();
+    const departmentId = objectId();
+    const dto: ChangeUserRoleDto = {
+      role: Role.TEACHER,
+      departmentId,
+      position: 'Професор',
+    };
+
+    model.findById.mockReturnValue(
+      query({
+        role: Role.STUDENT,
+        status: 'active',
+      }),
+    );
+    model.findByIdAndUpdate.mockReturnValue(
+      query(
+        userResponse({
+          _id: userId,
+          role: Role.TEACHER,
+          teacherProfile: {
+            department: departmentId,
+            position: 'Професор',
+          },
+        }),
+      ),
+    );
+
+    const result = await service.changeRole(userId, dto, objectId());
+
+    expect(model.findByIdAndUpdate).toHaveBeenCalledWith(
+      userId,
+      {
+        $set: {
+          role: Role.TEACHER,
+          teacherProfile: {
+            department: departmentId,
+            position: 'Професор',
+          },
+        },
+        $unset: {
+          studentProfile: '',
+        },
+      },
+      { returnDocument: 'after' },
+    );
+    expect(removeAllRefreshTokenHashesSpy).toHaveBeenCalledWith(userId);
+    expect(result.role).toBe(Role.TEACHER);
+  });
+
+  it('rejects self role changes before loading the target user', async () => {
+    const userId = objectId();
+
+    await expect(
+      service.changeRole(userId, { role: Role.DEAN }, userId),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+
+    expect(model.findById).not.toHaveBeenCalled();
+    expect(model.findByIdAndUpdate).not.toHaveBeenCalled();
+  });
+
+  it('also rejects self role changes through the general update endpoint', async () => {
+    const userId = objectId();
+
+    model.findById.mockReturnValue(
+      query({
+        role: Role.ADMIN,
+        status: 'active',
+      }),
+    );
+
+    await expect(
+      service.update(userId, { role: Role.DEAN }, userId),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+
+    expect(model.findById).toHaveBeenCalledWith(userId);
+    expect(model.findByIdAndUpdate).not.toHaveBeenCalled();
+  });
+
+  it('allows a general self update when the submitted role is unchanged', async () => {
+    const userId = objectId();
+
+    model.findById.mockReturnValue(
+      query({
+        role: Role.ADMIN,
+        status: 'active',
+      }),
+    );
+    model.findByIdAndUpdate.mockReturnValue(
+      query(
+        userResponse({
+          _id: userId,
+          role: Role.ADMIN,
+          firstName: 'Олег',
+        }),
+      ),
+    );
+
+    const result = await service.update(
+      userId,
+      { role: Role.ADMIN, firstName: 'Олег' },
+      userId,
+    );
+
+    expect(model.findByIdAndUpdate).toHaveBeenCalledWith(
+      userId,
+      {
+        $set: {
+          firstName: 'Олег',
+          role: Role.ADMIN,
+        },
+      },
+      { returnDocument: 'after' },
+    );
+    expect(removeAllRefreshTokenHashesSpy).not.toHaveBeenCalled();
+    expect(result.firstName).toBe('Олег');
+  });
+
+  it('requires a complete student profile when changing to student role', async () => {
+    const userId = objectId();
+
+    model.findById.mockReturnValue(
+      query({
+        role: Role.TEACHER,
+        status: 'active',
+      }),
+    );
+
+    await expect(
+      service.changeRole(
+        userId,
+        {
+          role: Role.STUDENT,
+          groupId: objectId(),
+          year: 1,
+        },
+        objectId(),
+      ),
+    ).rejects.toBeInstanceOf(BadRequestException);
+
+    expect(model.findByIdAndUpdate).not.toHaveBeenCalled();
+    expect(removeAllRefreshTokenHashesSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects duplicate student record book numbers', async () => {
+    const userId = objectId();
+
+    model.findById.mockReturnValue(
+      query({
+        role: Role.TEACHER,
+        status: 'active',
+      }),
+    );
+    model.findOne.mockReturnValue(query({ _id: objectId() }));
+
+    await expect(
+      service.changeRole(
+        userId,
+        {
+          role: Role.STUDENT,
+          groupId: objectId(),
+          recordBookNumber: 'КН-2026-001',
+          year: 1,
+        },
+        objectId(),
+      ),
+    ).rejects.toBeInstanceOf(ConflictException);
+
+    expect(model.findByIdAndUpdate).not.toHaveBeenCalled();
+    expect(removeAllRefreshTokenHashesSpy).not.toHaveBeenCalled();
+  });
+
+  it('protects the last active admin from demotion', async () => {
+    const userId = objectId();
+
+    model.findById.mockReturnValue(
+      query({
+        role: Role.ADMIN,
+        status: 'active',
+      }),
+    );
+    model.countDocuments.mockReturnValue(query(0));
+
+    await expect(
+      service.changeRole(userId, { role: Role.DISPATCHER }, objectId()),
+    ).rejects.toBeInstanceOf(BadRequestException);
+
+    expect(model.countDocuments).toHaveBeenCalledWith({
+      role: Role.ADMIN,
+      status: 'active',
+      _id: { $ne: userId },
+    });
+    expect(model.findByIdAndUpdate).not.toHaveBeenCalled();
+    expect(removeAllRefreshTokenHashesSpy).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/users/users.service.ts
+++ b/server/src/users/users.service.ts
@@ -1,11 +1,13 @@
 import {
+  BadRequestException,
   Injectable,
   NotFoundException,
   ConflictException,
+  ForbiddenException,
 } from '@nestjs/common';
 import * as bcrypt from 'bcryptjs';
 import { InjectModel } from '@nestjs/mongoose';
-import { PaginateModel } from 'mongoose';
+import { isValidObjectId, PaginateModel } from 'mongoose';
 import { User, UserDocument } from './schemas';
 import { Role } from '../common/types/roles.enum';
 import { UserDto } from './dto/user.dto';
@@ -18,11 +20,22 @@ import { PaginationDto } from '../common/dto/pagination.dto';
 import { PaginatedDto } from '../common/dto/paginated.dto';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
+import { ChangeUserRoleDto } from './dto/change-user-role.dto';
 import { toId } from '../common/utils/to-id.util';
 
 function escapeRegex(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
+
+type UserRoleState = {
+  role: Role;
+  status: string;
+};
+
+type RoleUpdateOperation = {
+  $set: Record<string, unknown>;
+  $unset?: Record<string, ''>;
+};
 
 @Injectable()
 export class UsersService {
@@ -158,7 +171,11 @@ export class UsersService {
     return transformToDto(UserDto, savedUser.toObject());
   }
 
-  async update(id: string, updateUserDto: UpdateUserDto): Promise<UserDto> {
+  async update(
+    id: string,
+    updateUserDto: UpdateUserDto,
+    actorId?: string,
+  ): Promise<UserDto> {
     const {
       login,
       email,
@@ -168,6 +185,7 @@ export class UsersService {
       year,
       departmentId,
       position,
+      role,
       ...rest
     } = updateUserDto;
 
@@ -201,30 +219,113 @@ export class UsersService {
       updateData.passwordHash = await bcrypt.hash(password, 12);
     }
 
-    const currentRole = rest.role ?? existingUser.role;
+    const unsetData: Record<string, ''> = {};
+    const roleChanged = role !== undefined && role !== existingUser.role;
 
-    if (currentRole === Role.STUDENT) {
-      updateData.studentProfile = {
-        group: groupId ?? existingUser.studentProfile?.group,
-        recordBookNumber:
-          recordBookNumber ?? existingUser.studentProfile?.recordBookNumber,
-        year: year !== undefined ? year : existingUser.studentProfile?.year,
-      };
-    } else if (currentRole === Role.TEACHER) {
-      updateData.teacherProfile = {
-        department: departmentId ?? existingUser.teacherProfile?.department,
-        position: position ?? existingUser.teacherProfile?.position,
-      };
+    if (roleChanged && actorId === id) {
+      throw new ForbiddenException('Неможливо змінити власну роль');
+    }
+
+    if (roleChanged) {
+      const roleUpdate = await this.createRoleUpdateOperation(
+        id,
+        {
+          role,
+          groupId,
+          recordBookNumber,
+          year,
+          departmentId,
+          position,
+        },
+        existingUser,
+      );
+
+      Object.assign(updateData, roleUpdate.$set);
+      if (roleUpdate.$unset) {
+        Object.assign(unsetData, roleUpdate.$unset);
+      }
+    } else {
+      if (role !== undefined) {
+        updateData.role = role;
+      }
+
+      if (existingUser.role === Role.STUDENT) {
+        updateData.studentProfile = {
+          group: groupId ?? existingUser.studentProfile?.group,
+          recordBookNumber:
+            recordBookNumber ?? existingUser.studentProfile?.recordBookNumber,
+          year: year !== undefined ? year : existingUser.studentProfile?.year,
+        };
+      } else if (existingUser.role === Role.TEACHER) {
+        updateData.teacherProfile = {
+          department: departmentId ?? existingUser.teacherProfile?.department,
+          position: position ?? existingUser.teacherProfile?.position,
+        };
+      }
+    }
+
+    const updateOperation: RoleUpdateOperation = { $set: updateData };
+    if (Object.keys(unsetData).length > 0) {
+      updateOperation.$unset = unsetData;
     }
 
     const updatedUser = await this.userModel
-      .findByIdAndUpdate(id, { $set: updateData }, { returnDocument: 'after' })
+      .findByIdAndUpdate(id, updateOperation, { returnDocument: 'after' })
       .lean()
       .exec();
 
     if (!updatedUser) {
       throw new NotFoundException('Користувача не знайдено');
     }
+
+    if (roleChanged) {
+      await this.removeAllRefreshTokenHashes(id);
+    }
+
+    return transformToDto(UserDto, updatedUser);
+  }
+
+  async changeRole(
+    id: string,
+    changeUserRoleDto: ChangeUserRoleDto,
+    actorId?: string,
+  ): Promise<UserDto> {
+    this.assertValidUserId(id);
+
+    if (actorId === id) {
+      throw new ForbiddenException('Неможливо змінити власну роль');
+    }
+
+    const existingUser = (await this.userModel
+      .findById(id)
+      .select('role status')
+      .lean()
+      .exec()) as UserRoleState | null;
+
+    if (!existingUser) {
+      throw new NotFoundException('Користувача не знайдено');
+    }
+
+    const roleChanged = existingUser.role !== changeUserRoleDto.role;
+    const roleUpdate = await this.createRoleUpdateOperation(
+      id,
+      changeUserRoleDto,
+      existingUser,
+    );
+
+    const updatedUser = await this.userModel
+      .findByIdAndUpdate(id, roleUpdate, { returnDocument: 'after' })
+      .lean()
+      .exec();
+
+    if (!updatedUser) {
+      throw new NotFoundException('Користувача не знайдено');
+    }
+
+    if (roleChanged) {
+      await this.removeAllRefreshTokenHashes(id);
+    }
+
     return transformToDto(UserDto, updatedUser);
   }
 
@@ -325,5 +426,198 @@ export class UsersService {
       .lean()
       .exec();
     return transformToDtoArray(UserDto, users);
+  }
+
+  private async createRoleUpdateOperation(
+    id: string,
+    dto: ChangeUserRoleDto,
+    existingUser: UserRoleState,
+  ): Promise<RoleUpdateOperation> {
+    this.assertProfileFieldsMatchRole(dto);
+    await this.assertCanChangeAdminRole(existingUser, dto.role, id);
+
+    if (dto.role === Role.STUDENT) {
+      const studentProfile = this.buildStudentProfile(dto);
+      await this.assertRecordBookNumberAvailable(
+        id,
+        studentProfile.recordBookNumber,
+      );
+
+      return {
+        $set: {
+          role: dto.role,
+          studentProfile,
+        },
+        $unset: {
+          teacherProfile: '',
+        },
+      };
+    }
+
+    if (dto.role === Role.TEACHER) {
+      return {
+        $set: {
+          role: dto.role,
+          teacherProfile: this.buildTeacherProfile(dto),
+        },
+        $unset: {
+          studentProfile: '',
+        },
+      };
+    }
+
+    return {
+      $set: {
+        role: dto.role,
+      },
+      $unset: {
+        studentProfile: '',
+        teacherProfile: '',
+      },
+    };
+  }
+
+  private assertValidUserId(id: string): void {
+    if (!isValidObjectId(id)) {
+      throw new BadRequestException('Некоректний id користувача');
+    }
+  }
+
+  private assertProfileFieldsMatchRole(dto: ChangeUserRoleDto): void {
+    if (!Object.values(Role).includes(dto.role)) {
+      throw new BadRequestException('Некоректна роль користувача');
+    }
+
+    const hasStudentFields =
+      dto.groupId !== undefined ||
+      dto.recordBookNumber !== undefined ||
+      dto.year !== undefined;
+    const hasTeacherFields =
+      dto.departmentId !== undefined || dto.position !== undefined;
+
+    if (dto.role === Role.STUDENT && hasTeacherFields) {
+      throw new BadRequestException(
+        'Поля профілю викладача не можна передавати для ролі студента',
+      );
+    }
+
+    if (dto.role === Role.TEACHER && hasStudentFields) {
+      throw new BadRequestException(
+        'Поля профілю студента не можна передавати для ролі викладача',
+      );
+    }
+
+    if (
+      dto.role !== Role.STUDENT &&
+      dto.role !== Role.TEACHER &&
+      (hasStudentFields || hasTeacherFields)
+    ) {
+      throw new BadRequestException(
+        'Профільні поля дозволені лише для ролей студента або викладача',
+      );
+    }
+  }
+
+  private buildStudentProfile(dto: ChangeUserRoleDto): {
+    group: string;
+    recordBookNumber: string;
+    year: number;
+  } {
+    const group = dto.groupId?.trim();
+    const recordBookNumber = dto.recordBookNumber?.trim();
+    const year = dto.year;
+
+    if (
+      !group ||
+      !recordBookNumber ||
+      typeof year !== 'number' ||
+      !Number.isInteger(year) ||
+      year < 1
+    ) {
+      throw new BadRequestException(
+        'Для ролі студента потрібно передати groupId, recordBookNumber та year',
+      );
+    }
+
+    if (!isValidObjectId(group)) {
+      throw new BadRequestException('Некоректний id групи');
+    }
+
+    return {
+      group,
+      recordBookNumber,
+      year,
+    };
+  }
+
+  private buildTeacherProfile(dto: ChangeUserRoleDto): {
+    department: string;
+    position: string;
+  } {
+    const department = dto.departmentId?.trim();
+    const position = dto.position?.trim();
+
+    if (!department || !position) {
+      throw new BadRequestException(
+        'Для ролі викладача потрібно передати departmentId та position',
+      );
+    }
+
+    if (!isValidObjectId(department)) {
+      throw new BadRequestException('Некоректний id кафедри');
+    }
+
+    return {
+      department,
+      position,
+    };
+  }
+
+  private async assertRecordBookNumberAvailable(
+    id: string,
+    recordBookNumber: string,
+  ): Promise<void> {
+    const duplicateUser = await this.userModel
+      .findOne({
+        'studentProfile.recordBookNumber': recordBookNumber,
+        _id: { $ne: id },
+      })
+      .select('_id')
+      .lean()
+      .exec();
+
+    if (duplicateUser) {
+      throw new ConflictException(
+        'Користувач з таким номером залікової книжки вже існує',
+      );
+    }
+  }
+
+  private async assertCanChangeAdminRole(
+    existingUser: UserRoleState,
+    nextRole: Role,
+    id: string,
+  ): Promise<void> {
+    if (
+      existingUser.role !== Role.ADMIN ||
+      existingUser.status !== 'active' ||
+      nextRole === Role.ADMIN
+    ) {
+      return;
+    }
+
+    const activeAdminsLeft = await this.userModel
+      .countDocuments({
+        role: Role.ADMIN,
+        status: 'active',
+        _id: { $ne: id },
+      })
+      .exec();
+
+    if (activeAdminsLeft === 0) {
+      throw new BadRequestException(
+        'Неможливо змінити роль останнього активного адміністратора',
+      );
+    }
   }
 }


### PR DESCRIPTION
## Summary

Fully completes backend task #4 by adding a dedicated user role change workflow and aligning the admin user edit UI with the new API contract.

## Changes

- Added `PATCH /api/users/:id/role` for dedicated user role changes.
- Added `ChangeUserRoleDto` with strict role-specific validation.
- Added safe role transition logic in `UsersService`.
- Clears incompatible profile data when switching roles:
  - student -> teacher clears `studentProfile`
  - teacher -> student clears `teacherProfile`
  - administrative/service roles clear both profiles
- Requires student profile data for `student` role changes.
- Requires teacher profile data for `teacher` role changes.
- Rejects duplicate student record book numbers.
- Blocks admins from changing their own role.
- Protects the last active admin from demotion.
- Resets refresh sessions after real role changes.
- Keeps the existing general `PATCH /users/:id` compatible while preventing role-change bypasses.
- Updated the admin user modal to call `/users/:id/role` when the role actually changes.
- Sends clean role-specific frontend payloads without stale profile fields.
- Added unit tests for the critical role change scenarios.

## Verification

- `client: npm run lint` passed
- `client: npm run build` passed
- `server: npm run lint` passed
- `server: npm run build` passed
- `server: npm test -- --runInBand` passed

##

Partially resolved #1
Closed #4