### PR TITLE
feat(references): complete reference lookup endpoints (Resolves #44) and protect referenced records from deletion (Resolves #43, #45)

### DIFF
--- a/server/src/references/classrooms.service.ts
+++ b/server/src/references/classrooms.service.ts
@@ -1,15 +1,24 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import { Classroom } from './schemas';
 import { ClassroomDto, CreateClassroomDto, UpdateClassroomDto } from './dto';
-import { transformToDtoArray } from '../common/utils/transform.util';
+import {
+  transformToDto,
+  transformToDtoArray,
+} from '../common/utils/transform.util';
+import { ReferenceIntegrityService } from './reference-integrity.service';
+import {
+  throwReferenceNotFound,
+  toReferenceObjectId,
+} from './reference-errors';
 
 @Injectable()
 export class ClassroomsService {
   constructor(
     @InjectModel(Classroom.name)
     private readonly classroomModel: Model<Classroom>,
+    private readonly referenceIntegrityService: ReferenceIntegrityService,
   ) {}
 
   async findAll(query: {
@@ -18,6 +27,20 @@ export class ClassroomsService {
   }): Promise<ClassroomDto[]> {
     const classrooms = await this.classroomModel.find(query).lean().exec();
     return transformToDtoArray(ClassroomDto, classrooms);
+  }
+
+  async findById(id: string): Promise<ClassroomDto> {
+    const objectId = toReferenceObjectId(id, 'classroom');
+    const classroom = await this.classroomModel
+      .findById(objectId)
+      .lean()
+      .exec();
+
+    if (!classroom) {
+      throwReferenceNotFound('Classroom', id);
+    }
+
+    return transformToDto(ClassroomDto, classroom);
   }
 
   async create(createClassroomDto: CreateClassroomDto): Promise<string> {
@@ -30,20 +53,32 @@ export class ClassroomsService {
     id: string,
     updateClassroomDto: UpdateClassroomDto,
   ): Promise<string> {
+    const objectId = toReferenceObjectId(id, 'classroom');
     const classroom = await this.classroomModel
-      .findByIdAndUpdate(id, updateClassroomDto, { new: true })
+      .findByIdAndUpdate(objectId, updateClassroomDto, { new: true })
       .lean()
       .exec();
     if (!classroom) {
-      throw new NotFoundException(`Classroom with ID ${id} not found`);
+      throwReferenceNotFound('Classroom', id);
     }
     return classroom._id.toString();
   }
 
   async remove(id: string): Promise<void> {
-    const result = await this.classroomModel.deleteOne({ _id: id }).exec();
+    const objectId = toReferenceObjectId(id, 'classroom');
+    const classroomExists = await this.classroomModel.exists({ _id: objectId });
+
+    if (!classroomExists) {
+      throwReferenceNotFound('Classroom', id);
+    }
+
+    this.referenceIntegrityService.assertClassroomCanBeDeleted(objectId);
+
+    const result = await this.classroomModel
+      .deleteOne({ _id: objectId })
+      .exec();
     if (result.deletedCount === 0) {
-      throw new NotFoundException(`Classroom with ID ${id} not found`);
+      throwReferenceNotFound('Classroom', id);
     }
   }
 }

--- a/server/src/references/departments.service.ts
+++ b/server/src/references/departments.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import { Department } from './schemas';
@@ -9,12 +9,18 @@ import {
   transformToDto,
   transformToDtoArray,
 } from '../common/utils/transform.util';
+import { ReferenceIntegrityService } from './reference-integrity.service';
+import {
+  throwReferenceNotFound,
+  toReferenceObjectId,
+} from './reference-errors';
 
 @Injectable()
 export class DepartmentsService {
   constructor(
     @InjectModel(Department.name)
     private readonly departmentModel: Model<Department>,
+    private readonly referenceIntegrityService: ReferenceIntegrityService,
   ) {}
 
   async findAll(): Promise<DepartmentDto[]> {
@@ -28,14 +34,15 @@ export class DepartmentsService {
   }
 
   async findById(id: string): Promise<DepartmentDto> {
+    const objectId = toReferenceObjectId(id, 'department');
     const department = await this.departmentModel
-      .findById(id)
+      .findById(objectId)
       .populate({ path: 'faculty', populate: { path: 'dean' } })
       .populate('head')
       .lean()
       .exec();
     if (!department) {
-      throw new NotFoundException(`Department with ID ${id} not found`);
+      throwReferenceNotFound('Department', id);
     }
     return transformToDto(DepartmentDto, department);
   }
@@ -50,19 +57,33 @@ export class DepartmentsService {
     id: string,
     updateDepartmentDto: UpdateDepartmentDto,
   ): Promise<string> {
+    const objectId = toReferenceObjectId(id, 'department');
     const department = await this.departmentModel
-      .findByIdAndUpdate(id, updateDepartmentDto, { new: true })
+      .findByIdAndUpdate(objectId, updateDepartmentDto, { new: true })
       .exec();
     if (!department) {
-      throw new NotFoundException(`Department with ID ${id} not found`);
+      throwReferenceNotFound('Department', id);
     }
     return department._id.toString();
   }
 
   async remove(id: string): Promise<void> {
-    const result = await this.departmentModel.deleteOne({ _id: id }).exec();
+    const objectId = toReferenceObjectId(id, 'department');
+    const departmentExists = await this.departmentModel.exists({
+      _id: objectId,
+    });
+
+    if (!departmentExists) {
+      throwReferenceNotFound('Department', id);
+    }
+
+    await this.referenceIntegrityService.assertDepartmentCanBeDeleted(objectId);
+
+    const result = await this.departmentModel
+      .deleteOne({ _id: objectId })
+      .exec();
     if (result.deletedCount === 0) {
-      throw new NotFoundException(`Department with ID ${id} not found`);
+      throwReferenceNotFound('Department', id);
     }
   }
 }

--- a/server/src/references/faculties.service.ts
+++ b/server/src/references/faculties.service.ts
@@ -1,14 +1,23 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import { Faculty } from './schemas';
 import { CreateFacultyDto, FacultyDto, UpdateFacultyDto } from './dto';
-import { transformToDtoArray } from '../common/utils/transform.util';
+import {
+  transformToDto,
+  transformToDtoArray,
+} from '../common/utils/transform.util';
+import { ReferenceIntegrityService } from './reference-integrity.service';
+import {
+  throwReferenceNotFound,
+  toReferenceObjectId,
+} from './reference-errors';
 
 @Injectable()
 export class FacultiesService {
   constructor(
     @InjectModel(Faculty.name) private readonly facultyModel: Model<Faculty>,
+    private readonly referenceIntegrityService: ReferenceIntegrityService,
   ) {}
 
   async findAll(): Promise<FacultyDto[]> {
@@ -18,6 +27,21 @@ export class FacultiesService {
       .lean()
       .exec();
     return transformToDtoArray(FacultyDto, faculties);
+  }
+
+  async findById(id: string): Promise<FacultyDto> {
+    const objectId = toReferenceObjectId(id, 'faculty');
+    const faculty = await this.facultyModel
+      .findById(objectId)
+      .populate('dean')
+      .lean()
+      .exec();
+
+    if (!faculty) {
+      throwReferenceNotFound('Faculty', id);
+    }
+
+    return transformToDto(FacultyDto, faculty);
   }
 
   async create(createFacultyDto: CreateFacultyDto): Promise<string> {
@@ -30,19 +54,29 @@ export class FacultiesService {
     id: string,
     updateFacultyDto: UpdateFacultyDto,
   ): Promise<string> {
+    const objectId = toReferenceObjectId(id, 'faculty');
     const faculty = await this.facultyModel
-      .findByIdAndUpdate(id, updateFacultyDto, { new: true })
+      .findByIdAndUpdate(objectId, updateFacultyDto, { new: true })
       .exec();
     if (!faculty) {
-      throw new NotFoundException(`Faculty with ID ${id} not found`);
+      throwReferenceNotFound('Faculty', id);
     }
     return faculty._id.toString();
   }
 
   async remove(id: string): Promise<void> {
-    const result = await this.facultyModel.deleteOne({ _id: id }).exec();
+    const objectId = toReferenceObjectId(id, 'faculty');
+    const facultyExists = await this.facultyModel.exists({ _id: objectId });
+
+    if (!facultyExists) {
+      throwReferenceNotFound('Faculty', id);
+    }
+
+    await this.referenceIntegrityService.assertFacultyCanBeDeleted(objectId);
+
+    const result = await this.facultyModel.deleteOne({ _id: objectId }).exec();
     if (result.deletedCount === 0) {
-      throw new NotFoundException(`Faculty with ID ${id} not found`);
+      throwReferenceNotFound('Faculty', id);
     }
   }
 }

--- a/server/src/references/groups.service.ts
+++ b/server/src/references/groups.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import { Group } from './schemas';
@@ -9,11 +9,17 @@ import {
   transformToDto,
   transformToDtoArray,
 } from '../common/utils/transform.util';
+import { ReferenceIntegrityService } from './reference-integrity.service';
+import {
+  throwReferenceNotFound,
+  toReferenceObjectId,
+} from './reference-errors';
 
 @Injectable()
 export class GroupsService {
   constructor(
     @InjectModel(Group.name) private readonly groupModel: Model<Group>,
+    private readonly referenceIntegrityService: ReferenceIntegrityService,
   ) {}
 
   async findAll(query: { course?: number }): Promise<GroupDto[]> {
@@ -27,14 +33,15 @@ export class GroupsService {
   }
 
   async findById(id: string): Promise<GroupDto> {
+    const objectId = toReferenceObjectId(id, 'group');
     const group = await this.groupModel
-      .findById(id)
+      .findById(objectId)
       .populate('specialty')
       .populate('curator')
       .lean() // Return plain JavaScript objects
       .exec();
     if (!group) {
-      throw new NotFoundException(`Group with ID ${id} not found`);
+      throwReferenceNotFound('Group', id);
     }
     return transformToDto(GroupDto, group);
   }
@@ -46,19 +53,29 @@ export class GroupsService {
   }
 
   async update(id: string, updateGroupDto: UpdateGroupDto): Promise<string> {
+    const objectId = toReferenceObjectId(id, 'group');
     const group = await this.groupModel
-      .findByIdAndUpdate(id, updateGroupDto, { new: true })
+      .findByIdAndUpdate(objectId, updateGroupDto, { new: true })
       .exec();
     if (!group) {
-      throw new NotFoundException(`Group with ID ${id} not found`);
+      throwReferenceNotFound('Group', id);
     }
     return group._id.toString();
   }
 
   async remove(id: string): Promise<void> {
-    const result = await this.groupModel.deleteOne({ _id: id }).exec();
+    const objectId = toReferenceObjectId(id, 'group');
+    const groupExists = await this.groupModel.exists({ _id: objectId });
+
+    if (!groupExists) {
+      throwReferenceNotFound('Group', id);
+    }
+
+    await this.referenceIntegrityService.assertGroupCanBeDeleted(objectId);
+
+    const result = await this.groupModel.deleteOne({ _id: objectId }).exec();
     if (result.deletedCount === 0) {
-      throw new NotFoundException(`Group with ID ${id} not found`);
+      throwReferenceNotFound('Group', id);
     }
   }
 }

--- a/server/src/references/reference-errors.ts
+++ b/server/src/references/reference-errors.ts
@@ -1,0 +1,45 @@
+import {
+  BadRequestException,
+  ConflictException,
+  NotFoundException,
+} from '@nestjs/common';
+import { Types } from 'mongoose';
+
+export type ReferenceUsage = {
+  resource: string;
+  count: number;
+};
+
+export function toReferenceObjectId(
+  id: string,
+  resourceName = 'reference',
+): Types.ObjectId {
+  if (!Types.ObjectId.isValid(id)) {
+    throw new BadRequestException(`Некоректний id довідника: ${resourceName}`);
+  }
+
+  return new Types.ObjectId(id);
+}
+
+export function throwReferenceNotFound(
+  resourceName: string,
+  id: string,
+): never {
+  throw new NotFoundException(`${resourceName} with ID ${id} not found`);
+}
+
+export function throwReferenceInUse(
+  resourceName: string,
+  usages: ReferenceUsage[],
+): void {
+  const activeUsages = usages.filter((usage) => usage.count > 0);
+
+  if (activeUsages.length === 0) {
+    return;
+  }
+
+  throw new ConflictException({
+    message: `Неможливо видалити ${resourceName}: об'єкт використовується`,
+    usages: activeUsages,
+  });
+}

--- a/server/src/references/reference-integrity.service.spec.ts
+++ b/server/src/references/reference-integrity.service.spec.ts
@@ -1,0 +1,124 @@
+import { ConflictException } from '@nestjs/common';
+import { Types } from 'mongoose';
+import { ReferenceIntegrityService } from './reference-integrity.service';
+
+type CountModelMock = {
+  countDocuments: jest.Mock;
+};
+
+type ScheduleServiceMock = {
+  isClassroomUsed: jest.Mock;
+};
+
+function countQuery(count: number) {
+  return {
+    exec: jest.fn().mockResolvedValue(count),
+  };
+}
+
+function modelWithCount(count = 0): CountModelMock {
+  return {
+    countDocuments: jest.fn().mockReturnValue(countQuery(count)),
+  };
+}
+
+function createService(
+  overrides: {
+    departmentCount?: number;
+    groupCount?: number;
+    userCounts?: number[];
+    courseCount?: number;
+    courseAssignmentCount?: number;
+    assignmentCount?: number;
+    surveyCount?: number;
+    classroomUsed?: boolean;
+  } = {},
+) {
+  const userCounts = overrides.userCounts ?? [0, 0];
+  const userModel: CountModelMock = {
+    countDocuments: jest
+      .fn()
+      .mockReturnValueOnce(countQuery(userCounts[0] ?? 0))
+      .mockReturnValueOnce(countQuery(userCounts[1] ?? 0)),
+  };
+  const scheduleService: ScheduleServiceMock = {
+    isClassroomUsed: jest
+      .fn()
+      .mockReturnValue(overrides.classroomUsed ?? false),
+  };
+
+  const service = new ReferenceIntegrityService(
+    modelWithCount(overrides.departmentCount) as never,
+    modelWithCount(overrides.groupCount) as never,
+    userModel as never,
+    modelWithCount(overrides.courseCount) as never,
+    modelWithCount(overrides.courseAssignmentCount) as never,
+    modelWithCount(overrides.assignmentCount) as never,
+    modelWithCount(overrides.surveyCount) as never,
+    scheduleService as never,
+  );
+
+  return { service, userModel, scheduleService };
+}
+
+describe('ReferenceIntegrityService', () => {
+  const id = new Types.ObjectId();
+
+  it('allows deleting a reference when no related documents exist', async () => {
+    const { service } = createService();
+
+    await expect(
+      service.assertFacultyCanBeDeleted(id),
+    ).resolves.toBeUndefined();
+    await expect(
+      service.assertDepartmentCanBeDeleted(id),
+    ).resolves.toBeUndefined();
+    await expect(service.assertGroupCanBeDeleted(id)).resolves.toBeUndefined();
+    await expect(
+      service.assertSpecialtyCanBeDeleted(id),
+    ).resolves.toBeUndefined();
+  });
+
+  it('blocks deleting faculties that still have departments', async () => {
+    const { service } = createService({ departmentCount: 2 });
+
+    await expect(service.assertFacultyCanBeDeleted(id)).rejects.toThrow(
+      ConflictException,
+    );
+  });
+
+  it('blocks deleting departments used by courses or teacher profiles', async () => {
+    const { service } = createService({
+      courseCount: 1,
+      userCounts: [3, 0],
+    });
+
+    await expect(service.assertDepartmentCanBeDeleted(id)).rejects.toThrow(
+      ConflictException,
+    );
+  });
+
+  it('blocks deleting groups used by students, courses, assignments, or surveys', async () => {
+    const { service } = createService({
+      userCounts: [4, 0],
+      courseAssignmentCount: 2,
+      assignmentCount: 1,
+      surveyCount: 1,
+    });
+
+    await expect(service.assertGroupCanBeDeleted(id)).rejects.toThrow(
+      ConflictException,
+    );
+  });
+
+  it('blocks deleting classrooms used by active schedule entries', () => {
+    const { service, scheduleService } = createService({ classroomUsed: true });
+
+    expect(() => service.assertClassroomCanBeDeleted(id)).toThrow(
+      ConflictException,
+    );
+    expect(scheduleService.isClassroomUsed).toHaveBeenCalledWith(
+      id.toHexString(),
+    );
+  });
+});

--- a/server/src/references/reference-integrity.service.ts
+++ b/server/src/references/reference-integrity.service.ts
@@ -1,0 +1,115 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model, Types } from 'mongoose';
+import {
+  Assignment,
+  AssignmentDocument,
+  Course,
+  CourseAssignment,
+  CourseAssignmentDocument,
+  CourseDocument,
+} from '../courses/schemas';
+import { ScheduleService } from '../schedule/schedule.service';
+import { Survey, SurveyDocument, SurveyTargetType } from '../surveys/schemas';
+import { User, UserDocument } from '../users/schemas';
+import { Department, Group } from './schemas';
+import { throwReferenceInUse } from './reference-errors';
+
+@Injectable()
+export class ReferenceIntegrityService {
+  constructor(
+    @InjectModel(Department.name)
+    private readonly departmentModel: Model<Department>,
+    @InjectModel(Group.name)
+    private readonly groupModel: Model<Group>,
+    @InjectModel(User.name)
+    private readonly userModel: Model<UserDocument>,
+    @InjectModel(Course.name)
+    private readonly courseModel: Model<CourseDocument>,
+    @InjectModel(CourseAssignment.name)
+    private readonly courseAssignmentModel: Model<CourseAssignmentDocument>,
+    @InjectModel(Assignment.name)
+    private readonly assignmentModel: Model<AssignmentDocument>,
+    @InjectModel(Survey.name)
+    private readonly surveyModel: Model<SurveyDocument>,
+    private readonly scheduleService: ScheduleService,
+  ) {}
+
+  async assertFacultyCanBeDeleted(id: Types.ObjectId): Promise<void> {
+    throwReferenceInUse('faculty', [
+      {
+        resource: 'departments',
+        count: await this.departmentModel
+          .countDocuments({ faculty: id })
+          .exec(),
+      },
+    ]);
+  }
+
+  async assertDepartmentCanBeDeleted(id: Types.ObjectId): Promise<void> {
+    throwReferenceInUse('department', [
+      {
+        resource: 'courses',
+        count: await this.courseModel.countDocuments({ department: id }).exec(),
+      },
+      {
+        resource: 'teacherProfiles',
+        count: await this.userModel
+          .countDocuments({
+            'teacherProfile.department': id as unknown as Department,
+          })
+          .exec(),
+      },
+    ]);
+  }
+
+  async assertSpecialtyCanBeDeleted(id: Types.ObjectId): Promise<void> {
+    throwReferenceInUse('specialty', [
+      {
+        resource: 'groups',
+        count: await this.groupModel.countDocuments({ specialty: id }).exec(),
+      },
+    ]);
+  }
+
+  async assertGroupCanBeDeleted(id: Types.ObjectId): Promise<void> {
+    const idString = id.toHexString();
+
+    throwReferenceInUse('group', [
+      {
+        resource: 'studentProfiles',
+        count: await this.userModel
+          .countDocuments({ 'studentProfile.group': id as unknown as Group })
+          .exec(),
+      },
+      {
+        resource: 'courseAssignments',
+        count: await this.courseAssignmentModel
+          .countDocuments({ group: id })
+          .exec(),
+      },
+      {
+        resource: 'assignments',
+        count: await this.assignmentModel.countDocuments({ group: id }).exec(),
+      },
+      {
+        resource: 'surveys',
+        count: await this.surveyModel
+          .countDocuments({
+            targetType: SurveyTargetType.GROUPS,
+            targetIds: idString,
+          })
+          .exec(),
+      },
+    ]);
+  }
+
+  assertClassroomCanBeDeleted(id: Types.ObjectId): void {
+    throwReferenceInUse('classroom', [
+      {
+        resource: 'scheduleEntries',
+        count: this.scheduleService.isClassroomUsed(id.toHexString()) ? 1 : 0,
+      },
+    ]);
+  }
+}

--- a/server/src/references/references.controller.ts
+++ b/server/src/references/references.controller.ts
@@ -97,6 +97,7 @@ export class ReferencesController {
   @UseGuards(RolesGuard)
   @Roles(Role.ADMIN)
   @ApiResponse({ status: 204, description: 'Group successfully deleted.' })
+  @ApiResponse({ status: 409, description: 'Group is in use.' })
   removeGroup(@Param('id') id: string) {
     return this.groupsService.remove(id);
   }
@@ -117,6 +118,12 @@ export class ReferencesController {
       query.building = building;
     }
     return this.classroomsService.findAll(query);
+  }
+
+  @Get('classrooms/:id')
+  @ApiResponse({ status: 200, type: ClassroomDto })
+  getClassroomById(@Param('id') id: string) {
+    return this.classroomsService.findById(id);
   }
 
   @Post('classrooms')
@@ -151,6 +158,7 @@ export class ReferencesController {
   @UseGuards(RolesGuard)
   @Roles(Role.ADMIN)
   @ApiResponse({ status: 204, description: 'Classroom successfully deleted.' })
+  @ApiResponse({ status: 409, description: 'Classroom is in use.' })
   removeClassroom(@Param('id') id: string) {
     return this.classroomsService.remove(id);
   }
@@ -199,6 +207,7 @@ export class ReferencesController {
   @UseGuards(RolesGuard)
   @Roles(Role.ADMIN)
   @ApiResponse({ status: 204, description: 'Department successfully deleted.' })
+  @ApiResponse({ status: 409, description: 'Department is in use.' })
   removeDepartment(@Param('id') id: string) {
     return this.departmentsService.remove(id);
   }
@@ -207,6 +216,12 @@ export class ReferencesController {
   @ApiResponse({ status: 200, type: [FacultyDto] })
   getFaculties() {
     return this.facultiesService.findAll();
+  }
+
+  @Get('faculties/:id')
+  @ApiResponse({ status: 200, type: FacultyDto })
+  getFacultyById(@Param('id') id: string) {
+    return this.facultiesService.findById(id);
   }
 
   @Post('faculties')
@@ -241,6 +256,7 @@ export class ReferencesController {
   @UseGuards(RolesGuard)
   @Roles(Role.ADMIN)
   @ApiResponse({ status: 204, description: 'Faculty successfully deleted.' })
+  @ApiResponse({ status: 409, description: 'Faculty is in use.' })
   removeFaculty(@Param('id') id: string) {
     return this.facultiesService.remove(id);
   }
@@ -249,6 +265,12 @@ export class ReferencesController {
   @ApiResponse({ status: 200, type: [SpecialtyDto] })
   getSpecialties() {
     return this.specialtiesService.findAll();
+  }
+
+  @Get('specialties/:id')
+  @ApiResponse({ status: 200, type: SpecialtyDto })
+  getSpecialtyById(@Param('id') id: string) {
+    return this.specialtiesService.findById(id);
   }
 
   @Post('specialties')
@@ -283,6 +305,7 @@ export class ReferencesController {
   @UseGuards(RolesGuard)
   @Roles(Role.ADMIN)
   @ApiResponse({ status: 204, description: 'Specialty successfully deleted.' })
+  @ApiResponse({ status: 409, description: 'Specialty is in use.' })
   removeSpecialty(@Param('id') id: string) {
     return this.specialtiesService.remove(id);
   }

--- a/server/src/references/references.module.ts
+++ b/server/src/references/references.module.ts
@@ -1,5 +1,16 @@
 import { Module } from '@nestjs/common';
 import { MongooseModule } from '@nestjs/mongoose';
+import {
+  Assignment,
+  AssignmentSchema,
+  Course,
+  CourseAssignment,
+  CourseAssignmentSchema,
+  CourseSchema,
+} from '../courses/schemas';
+import { ScheduleModule } from '../schedule/schedule.module';
+import { Survey, SurveySchema } from '../surveys/schemas';
+import { User, UserSchema } from '../users/schemas';
 import { ReferencesController } from './references.controller';
 import {
   Classroom,
@@ -18,6 +29,7 @@ import { ClassroomsService } from './classrooms.service';
 import { DepartmentsService } from './departments.service';
 import { FacultiesService } from './faculties.service';
 import { SpecialtiesService } from './specialties.service';
+import { ReferenceIntegrityService } from './reference-integrity.service';
 
 @Module({
   imports: [
@@ -27,10 +39,17 @@ import { SpecialtiesService } from './specialties.service';
       { name: Department.name, schema: DepartmentSchema },
       { name: Faculty.name, schema: FacultySchema },
       { name: Specialty.name, schema: SpecialtySchema },
+      { name: User.name, schema: UserSchema },
+      { name: Course.name, schema: CourseSchema },
+      { name: CourseAssignment.name, schema: CourseAssignmentSchema },
+      { name: Assignment.name, schema: AssignmentSchema },
+      { name: Survey.name, schema: SurveySchema },
     ]),
+    ScheduleModule,
   ],
   controllers: [ReferencesController],
   providers: [
+    ReferenceIntegrityService,
     GroupsService,
     ClassroomsService,
     DepartmentsService,

--- a/server/src/references/specialties.service.ts
+++ b/server/src/references/specialties.service.ts
@@ -1,20 +1,43 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import { Specialty } from './schemas';
 import { CreateSpecialtyDto, SpecialtyDto, UpdateSpecialtyDto } from './dto';
-import { transformToDtoArray } from '../common/utils/transform.util';
+import {
+  transformToDto,
+  transformToDtoArray,
+} from '../common/utils/transform.util';
+import { ReferenceIntegrityService } from './reference-integrity.service';
+import {
+  throwReferenceNotFound,
+  toReferenceObjectId,
+} from './reference-errors';
 
 @Injectable()
 export class SpecialtiesService {
   constructor(
     @InjectModel(Specialty.name)
     private readonly specialtyModel: Model<Specialty>,
+    private readonly referenceIntegrityService: ReferenceIntegrityService,
   ) {}
 
   async findAll(): Promise<SpecialtyDto[]> {
     const specialties = await this.specialtyModel.find().lean().exec();
     return transformToDtoArray(SpecialtyDto, specialties);
+  }
+
+  async findById(id: string): Promise<SpecialtyDto> {
+    const objectId = toReferenceObjectId(id, 'specialty');
+    const specialty = await this.specialtyModel
+      .findById(objectId)
+      .lean()
+      .exec();
+
+    if (!specialty) {
+      throwReferenceNotFound('Specialty', id);
+    }
+
+    return transformToDto(SpecialtyDto, specialty);
   }
 
   async create(createSpecialtyDto: CreateSpecialtyDto): Promise<string> {
@@ -27,19 +50,31 @@ export class SpecialtiesService {
     id: string,
     updateSpecialtyDto: UpdateSpecialtyDto,
   ): Promise<string> {
+    const objectId = toReferenceObjectId(id, 'specialty');
     const specialty = await this.specialtyModel
-      .findByIdAndUpdate(id, updateSpecialtyDto, { new: true })
+      .findByIdAndUpdate(objectId, updateSpecialtyDto, { new: true })
       .exec();
     if (!specialty) {
-      throw new NotFoundException(`Specialty with ID ${id} not found`);
+      throwReferenceNotFound('Specialty', id);
     }
     return specialty._id.toString();
   }
 
   async remove(id: string): Promise<void> {
-    const result = await this.specialtyModel.deleteOne({ _id: id }).exec();
+    const objectId = toReferenceObjectId(id, 'specialty');
+    const specialtyExists = await this.specialtyModel.exists({ _id: objectId });
+
+    if (!specialtyExists) {
+      throwReferenceNotFound('Specialty', id);
+    }
+
+    await this.referenceIntegrityService.assertSpecialtyCanBeDeleted(objectId);
+
+    const result = await this.specialtyModel
+      .deleteOne({ _id: objectId })
+      .exec();
     if (result.deletedCount === 0) {
-      throw new NotFoundException(`Specialty with ID ${id} not found`);
+      throwReferenceNotFound('Specialty', id);
     }
   }
 }

--- a/server/src/schedule/schedule.module.ts
+++ b/server/src/schedule/schedule.module.ts
@@ -5,5 +5,6 @@ import { ScheduleService } from './schedule.service';
 @Module({
   controllers: [ScheduleController],
   providers: [ScheduleService],
+  exports: [ScheduleService],
 })
 export class ScheduleModule {}

--- a/server/src/schedule/schedule.service.ts
+++ b/server/src/schedule/schedule.service.ts
@@ -82,6 +82,13 @@ export class ScheduleService {
     return { deleted: true };
   }
 
+  isClassroomUsed(classroomId: string): boolean {
+    return this.entries.some(
+      (entry) =>
+        entry.classroomId === classroomId && entry.status !== 'cancelled',
+    );
+  }
+
   private checkConflicts(dto: Omit<ScheduleEntry, 'id'>) {
     const conflicts: string[] = [];
     const ca = courseAssignments.find((c) => c.id === dto.courseAssignmentId);


### PR DESCRIPTION
## Summary

Completes the References CRUD API follow-up work from #43 by finishing #45 and tightening the already closed #44 implementation.

## Changes

- Added missing `GET by id` endpoints for:
  - `GET /references/classrooms/:id`
  - `GET /references/faculties/:id`
  - `GET /references/specialties/:id`
- Added shared reference ObjectId validation and consistent not found handling.
- Added reference integrity checks before deletion.
- Blocks deletion with `409 Conflict` when a reference is still used.
- Protects:
  - faculties used by departments
  - departments used by courses or teacher profiles
  - specialties used by groups
  - groups used by students, course assignments, assignments, or surveys
  - classrooms used by active schedule entries
- Exported `ScheduleService` so reference integrity checks can validate classroom usage.
- Added unit tests for the reference integrity rules.

## Verification

- `server: npm run lint` passed
- `server: npm run build` passed
- `server: npm test -- --runInBand` passed
- `client: npm run lint` passed
- `client: npm run build` passed
- `server: npm audit --audit-level=high` passed with 0 vulnerabilities
- `client: npm audit --audit-level=high` passed with 0 vulnerabilities

##

Closed #43
Closed #44
Closed #45