### PR TITLE
feat(schedule): add DB-backed schedule conflicts, notifications and CSV export (Resolves #36, #37, #38, #39)

### DIFF
--- a/server/src/notifications/notifications.service.ts
+++ b/server/src/notifications/notifications.service.ts
@@ -29,6 +29,22 @@ export class NotificationsService {
     });
   }
 
+  async createMany(items: CreateNotificationDto[]) {
+    if (items.length === 0) {
+      return [];
+    }
+
+    return this.notificationModel.insertMany(
+      items.map((data) => ({
+        title: data.title,
+        message: data.message,
+        type: data.type,
+        userId: data.userId ? new Types.ObjectId(data.userId) : null,
+      })),
+      { ordered: false },
+    );
+  }
+
   async findByUser(userId: string) {
     const userObjId = this.toObjectId(userId);
 

--- a/server/src/references/classrooms.service.ts
+++ b/server/src/references/classrooms.service.ts
@@ -72,7 +72,7 @@ export class ClassroomsService {
       throwReferenceNotFound('Classroom', id);
     }
 
-    this.referenceIntegrityService.assertClassroomCanBeDeleted(objectId);
+    await this.referenceIntegrityService.assertClassroomCanBeDeleted(objectId);
 
     const result = await this.classroomModel
       .deleteOne({ _id: objectId })

--- a/server/src/references/reference-integrity.service.spec.ts
+++ b/server/src/references/reference-integrity.service.spec.ts
@@ -44,7 +44,7 @@ function createService(
   const scheduleService: ScheduleServiceMock = {
     isClassroomUsed: jest
       .fn()
-      .mockReturnValue(overrides.classroomUsed ?? false),
+      .mockResolvedValue(overrides.classroomUsed ?? false),
   };
 
   const service = new ReferenceIntegrityService(
@@ -111,10 +111,10 @@ describe('ReferenceIntegrityService', () => {
     );
   });
 
-  it('blocks deleting classrooms used by active schedule entries', () => {
+  it('blocks deleting classrooms used by active schedule entries', async () => {
     const { service, scheduleService } = createService({ classroomUsed: true });
 
-    expect(() => service.assertClassroomCanBeDeleted(id)).toThrow(
+    await expect(service.assertClassroomCanBeDeleted(id)).rejects.toThrow(
       ConflictException,
     );
     expect(scheduleService.isClassroomUsed).toHaveBeenCalledWith(

--- a/server/src/references/reference-integrity.service.ts
+++ b/server/src/references/reference-integrity.service.ts
@@ -104,11 +104,13 @@ export class ReferenceIntegrityService {
     ]);
   }
 
-  assertClassroomCanBeDeleted(id: Types.ObjectId): void {
+  async assertClassroomCanBeDeleted(id: Types.ObjectId): Promise<void> {
     throwReferenceInUse('classroom', [
       {
         resource: 'scheduleEntries',
-        count: this.scheduleService.isClassroomUsed(id.toHexString()) ? 1 : 0,
+        count: (await this.scheduleService.isClassroomUsed(id.toHexString()))
+          ? 1
+          : 0,
       },
     ]);
   }

--- a/server/src/schedule/dto/create-schedule-entry.dto.ts
+++ b/server/src/schedule/dto/create-schedule-entry.dto.ts
@@ -1,0 +1,40 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsEnum, IsMongoId, IsOptional, Matches } from 'class-validator';
+import { ScheduleEntryStatus, ScheduleEntryType } from '../schemas';
+
+export class CreateScheduleEntryDto {
+  @ApiProperty()
+  @IsMongoId()
+  courseAssignmentId: string;
+
+  @ApiPropertyOptional({
+    description: 'Classroom id. Empty means online or no classroom assigned.',
+  })
+  @IsOptional()
+  @IsMongoId()
+  classroomId?: string;
+
+  @ApiProperty({ example: '2026-09-01' })
+  @Matches(/^\d{4}-\d{2}-\d{2}$/)
+  date: string;
+
+  @ApiProperty({ example: '08:30' })
+  @Matches(/^([01]\d|2[0-3]):[0-5]\d$/)
+  startTime: string;
+
+  @ApiProperty({ example: '10:05' })
+  @Matches(/^([01]\d|2[0-3]):[0-5]\d$/)
+  endTime: string;
+
+  @ApiProperty({ enum: ScheduleEntryType })
+  @IsEnum(ScheduleEntryType)
+  type: ScheduleEntryType;
+
+  @ApiPropertyOptional({
+    enum: ScheduleEntryStatus,
+    default: ScheduleEntryStatus.SCHEDULED,
+  })
+  @IsOptional()
+  @IsEnum(ScheduleEntryStatus)
+  status?: ScheduleEntryStatus;
+}

--- a/server/src/schedule/dto/index.ts
+++ b/server/src/schedule/dto/index.ts
@@ -1,0 +1,4 @@
+export * from './create-schedule-entry.dto';
+export * from './schedule-entry.dto';
+export * from './schedule-query.dto';
+export * from './update-schedule-entry.dto';

--- a/server/src/schedule/dto/schedule-entry.dto.ts
+++ b/server/src/schedule/dto/schedule-entry.dto.ts
@@ -1,0 +1,52 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { ScheduleEntryStatus, ScheduleEntryType } from '../schemas';
+
+export class ScheduleEntryDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  courseAssignmentId: string;
+
+  @ApiPropertyOptional()
+  classroomId?: string;
+
+  @ApiProperty()
+  date: string;
+
+  @ApiProperty()
+  startTime: string;
+
+  @ApiProperty()
+  endTime: string;
+
+  @ApiProperty({ enum: ScheduleEntryType })
+  type: ScheduleEntryType;
+
+  @ApiProperty({ enum: ScheduleEntryStatus })
+  status: ScheduleEntryStatus;
+
+  @ApiPropertyOptional()
+  courseName?: string;
+
+  @ApiPropertyOptional()
+  courseCode?: string;
+
+  @ApiPropertyOptional()
+  groupCode?: string;
+
+  @ApiPropertyOptional()
+  teacherId?: string;
+
+  @ApiPropertyOptional()
+  teacherName?: string;
+
+  @ApiPropertyOptional()
+  classroom?: string;
+
+  @ApiPropertyOptional()
+  createdAt?: string;
+
+  @ApiPropertyOptional()
+  updatedAt?: string;
+}

--- a/server/src/schedule/dto/schedule-query.dto.ts
+++ b/server/src/schedule/dto/schedule-query.dto.ts
@@ -1,0 +1,35 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsEnum, IsMongoId, IsOptional, Matches } from 'class-validator';
+import { ScheduleEntryStatus } from '../schemas';
+
+export class ScheduleQueryDto {
+  @ApiPropertyOptional({ example: '2026-09-01' })
+  @IsOptional()
+  @Matches(/^\d{4}-\d{2}-\d{2}$/)
+  date?: string;
+
+  @ApiPropertyOptional({ example: '2026-09-01' })
+  @IsOptional()
+  @Matches(/^\d{4}-\d{2}-\d{2}$/)
+  startDate?: string;
+
+  @ApiPropertyOptional({ example: '2026-09-07' })
+  @IsOptional()
+  @Matches(/^\d{4}-\d{2}-\d{2}$/)
+  endDate?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsMongoId()
+  groupId?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsMongoId()
+  teacherId?: string;
+
+  @ApiPropertyOptional({ enum: ScheduleEntryStatus })
+  @IsOptional()
+  @IsEnum(ScheduleEntryStatus)
+  status?: ScheduleEntryStatus;
+}

--- a/server/src/schedule/dto/update-schedule-entry.dto.ts
+++ b/server/src/schedule/dto/update-schedule-entry.dto.ts
@@ -1,0 +1,6 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateScheduleEntryDto } from './create-schedule-entry.dto';
+
+export class UpdateScheduleEntryDto extends PartialType(
+  CreateScheduleEntryDto,
+) {}

--- a/server/src/schedule/schedule.controller.ts
+++ b/server/src/schedule/schedule.controller.ts
@@ -1,21 +1,34 @@
 import {
+  Body,
   Controller,
+  Delete,
   Get,
+  Header,
+  Param,
   Post,
   Put,
-  Delete,
-  Body,
-  Param,
   Query,
-  UseGuards,
   Request,
+  Res,
+  UseGuards,
 } from '@nestjs/common';
-import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { Response } from 'express';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
-import { RolesGuard, Roles } from '../auth/roles.guard';
-import { Role } from '../common/types/roles.enum';
+import { Roles, RolesGuard } from '../auth/roles.guard';
 import { AuthenticatedRequest } from '../common/types/authenticated-request';
-import { ScheduleEntry } from '../common/types/entities';
+import { Role } from '../common/types/roles.enum';
+import {
+  CreateScheduleEntryDto,
+  ScheduleEntryDto,
+  ScheduleQueryDto,
+  UpdateScheduleEntryDto,
+} from './dto';
 import { ScheduleService } from './schedule.service';
 
 @ApiTags('schedule')
@@ -23,46 +36,67 @@ import { ScheduleService } from './schedule.service';
 @Controller('schedule')
 @UseGuards(JwtAuthGuard, RolesGuard)
 export class ScheduleController {
-  constructor(private scheduleService: ScheduleService) {}
+  constructor(private readonly scheduleService: ScheduleService) {}
 
   @Get()
+  @ApiOperation({ summary: 'List schedule entries visible to current user' })
+  @ApiResponse({ status: 200, type: [ScheduleEntryDto] })
   findAll(
-    @Query('date') date?: string,
-    @Query('groupId') groupId?: string,
-    @Query('teacherId') teacherId?: string,
+    @Query() query: ScheduleQueryDto,
+    @Request() req: AuthenticatedRequest,
   ) {
-    if (date) return this.scheduleService.findByDate(date);
-    if (groupId) return this.scheduleService.findByGroup(groupId);
-    if (teacherId) return this.scheduleService.findByTeacher(teacherId);
-    return this.scheduleService.findAll();
+    return this.scheduleService.findForUser(req.user, query);
   }
 
   @Get('my')
-  findMy(@Request() req: AuthenticatedRequest) {
-    const { sub, role } = req.user;
-    if (role === Role.STUDENT) {
-      return this.scheduleService.findByStudent(sub);
-    }
-    if (role === Role.TEACHER || role === Role.DEPARTMENT_HEAD) {
-      return this.scheduleService.findByTeacher(sub);
-    }
-    return this.scheduleService.findAll();
+  @ApiOperation({ summary: 'List current user schedule entries' })
+  @ApiResponse({ status: 200, type: [ScheduleEntryDto] })
+  findMy(
+    @Query() query: ScheduleQueryDto,
+    @Request() req: AuthenticatedRequest,
+  ) {
+    return this.scheduleService.findForUser(req.user, query);
+  }
+
+  @Get('export')
+  @Header('Content-Type', 'text/csv; charset=utf-8')
+  @ApiOperation({ summary: 'Export schedule entries as CSV' })
+  async exportCsv(
+    @Query() query: ScheduleQueryDto,
+    @Request() req: AuthenticatedRequest,
+    @Res({ passthrough: true }) res: Response,
+  ) {
+    const csv = await this.scheduleService.exportCsv(req.user, query);
+    res.setHeader('Content-Disposition', 'attachment; filename="schedule.csv"');
+    return csv;
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get schedule entry by id' })
+  @ApiResponse({ status: 200, type: ScheduleEntryDto })
+  findOne(@Param('id') id: string, @Request() req: AuthenticatedRequest) {
+    return this.scheduleService.findOneForUser(id, req.user);
   }
 
   @Post()
   @Roles(Role.DISPATCHER, Role.ADMIN)
-  create(@Body() body: Omit<ScheduleEntry, 'id'>) {
+  @ApiOperation({ summary: 'Create schedule entry with conflict checks' })
+  @ApiResponse({ status: 201, type: ScheduleEntryDto })
+  create(@Body() body: CreateScheduleEntryDto) {
     return this.scheduleService.create(body);
   }
 
   @Put(':id')
   @Roles(Role.DISPATCHER, Role.ADMIN)
-  update(@Param('id') id: string, @Body() body: Partial<ScheduleEntry>) {
+  @ApiOperation({ summary: 'Update schedule entry with conflict checks' })
+  @ApiResponse({ status: 200, type: ScheduleEntryDto })
+  update(@Param('id') id: string, @Body() body: UpdateScheduleEntryDto) {
     return this.scheduleService.update(id, body);
   }
 
   @Delete(':id')
   @Roles(Role.DISPATCHER, Role.ADMIN)
+  @ApiOperation({ summary: 'Delete schedule entry' })
   delete(@Param('id') id: string) {
     return this.scheduleService.delete(id);
   }

--- a/server/src/schedule/schedule.module.ts
+++ b/server/src/schedule/schedule.module.ts
@@ -1,8 +1,35 @@
 import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import {
+  Course,
+  CourseAssignment,
+  CourseAssignmentSchema,
+  CourseSchema,
+} from '../courses/schemas';
+import { NotificationsModule } from '../notifications/notifications.module';
+import {
+  Classroom,
+  ClassroomSchema,
+  Group,
+  GroupSchema,
+} from '../references/schemas';
+import { User, UserSchema } from '../users/schemas';
 import { ScheduleController } from './schedule.controller';
 import { ScheduleService } from './schedule.service';
+import { ScheduleEntry, ScheduleEntrySchema } from './schemas';
 
 @Module({
+  imports: [
+    MongooseModule.forFeature([
+      { name: ScheduleEntry.name, schema: ScheduleEntrySchema },
+      { name: CourseAssignment.name, schema: CourseAssignmentSchema },
+      { name: Course.name, schema: CourseSchema },
+      { name: Classroom.name, schema: ClassroomSchema },
+      { name: Group.name, schema: GroupSchema },
+      { name: User.name, schema: UserSchema },
+    ]),
+    NotificationsModule,
+  ],
   controllers: [ScheduleController],
   providers: [ScheduleService],
   exports: [ScheduleService],

--- a/server/src/schedule/schedule.service.spec.ts
+++ b/server/src/schedule/schedule.service.spec.ts
@@ -1,0 +1,224 @@
+import { ConflictException } from '@nestjs/common';
+import { Types } from 'mongoose';
+import { AuthenticatedUser } from '../common/types/authenticated-request';
+import { Role } from '../common/types/roles.enum';
+import { NotificationType } from '../notifications/dto/create-notification.dto';
+import { ScheduleService } from './schedule.service';
+import { ScheduleEntryStatus, ScheduleEntryType } from './schemas';
+
+type QueryChain<T> = {
+  populate: jest.Mock<QueryChain<T>, [unknown?]>;
+  select: jest.Mock<QueryChain<T>, [unknown?]>;
+  sort: jest.Mock<QueryChain<T>, [unknown?]>;
+  lean: jest.Mock<QueryChain<T>, []>;
+  exec: jest.Mock<Promise<T>, []>;
+};
+
+type ScheduleEntryModelMock = {
+  find: jest.Mock;
+  findById: jest.Mock;
+  create: jest.Mock;
+  countDocuments: jest.Mock;
+  deleteOne: jest.Mock;
+};
+
+type CourseAssignmentModelMock = {
+  find: jest.Mock;
+  findById: jest.Mock;
+};
+
+type ClassroomModelMock = {
+  exists: jest.Mock;
+};
+
+type UserModelMock = {
+  find: jest.Mock;
+  findById: jest.Mock;
+};
+
+type NotificationsServiceMock = {
+  createMany: jest.Mock;
+};
+
+function query<T>(result: T): QueryChain<T> {
+  const chain = {} as QueryChain<T>;
+  chain.populate = jest.fn<QueryChain<T>, [unknown?]>().mockReturnValue(chain);
+  chain.select = jest.fn<QueryChain<T>, [unknown?]>().mockReturnValue(chain);
+  chain.sort = jest.fn<QueryChain<T>, [unknown?]>().mockReturnValue(chain);
+  chain.lean = jest.fn<QueryChain<T>, []>().mockReturnValue(chain);
+  chain.exec = jest.fn<Promise<T>, []>().mockResolvedValue(result);
+  return chain;
+}
+
+function objectId(hex: string): Types.ObjectId {
+  return new Types.ObjectId(hex);
+}
+
+describe('ScheduleService', () => {
+  const ids = {
+    schedule: '6622b2a00f3a22d5b625e601',
+    scheduleConflict: '6622b2a00f3a22d5b625e602',
+    assignment: '6622b2a00f3a22d5b625e401',
+    course: '6622b2a00f3a22d5b625e301',
+    group: '6622b2a00f3a22d5b625e201',
+    classroom: '6622b2a00f3a22d5b625e501',
+    teacher: '6622b2a00f3a22d5b625e111',
+    student: '6622b2a00f3a22d5b625e101',
+  };
+
+  const assignment = {
+    _id: objectId(ids.assignment),
+    course: {
+      _id: objectId(ids.course),
+      name: 'Основи кібербезпеки',
+      code: '=SEC101',
+    },
+    group: {
+      _id: objectId(ids.group),
+      code: 'КН-11',
+    },
+    teacher: {
+      _id: objectId(ids.teacher),
+      firstName: 'Ірина',
+      lastName: 'Коваленко',
+    },
+  };
+
+  const scheduleEntry = {
+    _id: objectId(ids.schedule),
+    courseAssignment: assignment,
+    classroom: {
+      _id: objectId(ids.classroom),
+      building: 'Корпус 1',
+      roomNumber: '101',
+    },
+    date: new Date('2026-09-01T00:00:00.000Z'),
+    startTime: '08:30',
+    endTime: '10:05',
+    type: ScheduleEntryType.LECTURE,
+    status: ScheduleEntryStatus.SCHEDULED,
+  };
+
+  let scheduleEntryModel: ScheduleEntryModelMock;
+  let courseAssignmentModel: CourseAssignmentModelMock;
+  let classroomModel: ClassroomModelMock;
+  let userModel: UserModelMock;
+  let notificationsService: NotificationsServiceMock;
+  let service: ScheduleService;
+
+  beforeEach(() => {
+    scheduleEntryModel = {
+      find: jest.fn(),
+      findById: jest.fn(),
+      create: jest.fn(),
+      countDocuments: jest.fn(),
+      deleteOne: jest.fn(),
+    };
+    courseAssignmentModel = {
+      find: jest.fn(),
+      findById: jest.fn(),
+    };
+    classroomModel = {
+      exists: jest.fn(),
+    };
+    userModel = {
+      find: jest.fn(),
+      findById: jest.fn(),
+    };
+    notificationsService = {
+      createMany: jest.fn().mockResolvedValue([]),
+    };
+
+    service = new ScheduleService(
+      scheduleEntryModel as never,
+      courseAssignmentModel as never,
+      classroomModel as never,
+      userModel as never,
+      notificationsService as never,
+    );
+  });
+
+  it('rejects overlapping teacher, classroom, or group conflicts', async () => {
+    courseAssignmentModel.findById.mockReturnValue(query(assignment));
+    classroomModel.exists.mockReturnValue(query({ _id: ids.classroom }));
+    scheduleEntryModel.find.mockReturnValue(
+      query([
+        {
+          ...scheduleEntry,
+          _id: objectId(ids.scheduleConflict),
+        },
+      ]),
+    );
+
+    await expect(
+      service.create({
+        courseAssignmentId: ids.assignment,
+        classroomId: ids.classroom,
+        date: '2026-09-01',
+        startTime: '09:00',
+        endTime: '10:30',
+        type: ScheduleEntryType.SEMINAR,
+      }),
+    ).rejects.toThrow(ConflictException);
+
+    expect(scheduleEntryModel.create).not.toHaveBeenCalled();
+  });
+
+  it('creates targeted notifications after schedule creation', async () => {
+    courseAssignmentModel.findById.mockReturnValue(query(assignment));
+    courseAssignmentModel.find.mockReturnValue(
+      query([
+        {
+          _id: objectId(ids.assignment),
+          teacher: objectId(ids.teacher),
+          group: objectId(ids.group),
+        },
+      ]),
+    );
+    classroomModel.exists.mockReturnValue(query({ _id: ids.classroom }));
+    scheduleEntryModel.find.mockReturnValue(query([]));
+    scheduleEntryModel.findById.mockReturnValue(query(scheduleEntry));
+    scheduleEntryModel.create.mockResolvedValue({
+      _id: objectId(ids.schedule),
+    });
+    userModel.find.mockReturnValue(query([{ _id: objectId(ids.student) }]));
+
+    await service.create({
+      courseAssignmentId: ids.assignment,
+      classroomId: ids.classroom,
+      date: '2026-09-01',
+      startTime: '08:30',
+      endTime: '10:05',
+      type: ScheduleEntryType.LECTURE,
+    });
+
+    expect(notificationsService.createMany).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({
+          userId: ids.teacher,
+          type: NotificationType.SCHEDULE_CHANGE,
+        }),
+        expect.objectContaining({
+          userId: ids.student,
+          type: NotificationType.SCHEDULE_CHANGE,
+        }),
+      ]),
+    );
+  });
+
+  it('exports scoped schedule CSV and neutralizes spreadsheet formulas', async () => {
+    const user: AuthenticatedUser = {
+      sub: ids.teacher,
+      login: 'teacher',
+      role: Role.ADMIN,
+    };
+
+    scheduleEntryModel.find.mockReturnValue(query([scheduleEntry]));
+
+    const csv = await service.exportCsv(user, {});
+
+    expect(csv).toContain('date,start_time,end_time');
+    expect(csv).toContain("'=SEC101");
+    expect(csv).toContain('Основи кібербезпеки');
+  });
+});

--- a/server/src/schedule/schedule.service.ts
+++ b/server/src/schedule/schedule.service.ts
@@ -1,144 +1,867 @@
 import {
-  Injectable,
   BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  Injectable,
+  Logger,
   NotFoundException,
 } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model, Types } from 'mongoose';
+import { AuthenticatedUser } from '../common/types/authenticated-request';
+import { Role } from '../common/types/roles.enum';
+import { toId } from '../common/utils/to-id.util';
+import { CourseAssignment, CourseAssignmentDocument } from '../courses/schemas';
+import { NotificationType } from '../notifications/dto/create-notification.dto';
+import { NotificationsService } from '../notifications/notifications.service';
+import { Classroom } from '../references/schemas';
+import { User, UserDocument } from '../users/schemas';
 import {
-  scheduleEntries,
-  courseAssignments,
-  courses,
-  groups,
-  classrooms,
-  studentProfiles,
-} from '../common/mock-data';
-import { ScheduleEntry } from '../common/types/entities';
+  CreateScheduleEntryDto,
+  ScheduleEntryDto,
+  ScheduleQueryDto,
+  UpdateScheduleEntryDto,
+} from './dto';
+import {
+  ScheduleEntry,
+  ScheduleEntryDocument,
+  ScheduleEntryStatus,
+  ScheduleEntryType,
+} from './schemas';
+
+type EntityObject = { _id?: unknown; id?: unknown };
+type EntityRef = Types.ObjectId | string | EntityObject;
+
+type CourseLean = EntityObject & {
+  name?: string;
+  code?: string;
+};
+
+type GroupLean = EntityObject & {
+  code?: string;
+};
+
+type UserLean = EntityObject & {
+  firstName?: string;
+  lastName?: string;
+  middleName?: string;
+};
+
+type ClassroomLean = EntityObject & {
+  building?: string;
+  roomNumber?: string;
+};
+
+type CourseAssignmentLean = EntityObject & {
+  course?: CourseLean | EntityRef;
+  group?: GroupLean | EntityRef;
+  teacher?: UserLean | EntityRef;
+};
+
+type ScheduleEntryLean = {
+  _id: unknown;
+  courseAssignment?: CourseAssignmentLean | EntityRef;
+  classroom?: ClassroomLean | EntityRef | null;
+  date: Date | string;
+  startTime: string;
+  endTime: string;
+  type: ScheduleEntryType;
+  status: ScheduleEntryStatus;
+  createdAt?: Date;
+  updatedAt?: Date;
+};
+
+type NormalizedSchedulePayload = {
+  courseAssignmentId: string;
+  classroomId?: string;
+  date: Date;
+  dateString: string;
+  startTime: string;
+  endTime: string;
+  type: ScheduleEntryType;
+  status: ScheduleEntryStatus;
+  assignment: CourseAssignmentLean;
+};
+
+type ScheduleConflictType = 'teacher' | 'classroom' | 'group';
+
+type ScheduleConflict = {
+  type: ScheduleConflictType;
+  entryId: string;
+  date: string;
+  startTime: string;
+  endTime: string;
+  message: string;
+};
+
+type ScheduleChangeAction = 'created' | 'updated' | 'deleted';
+type ScheduleFilter = Record<string, unknown>;
+type CourseAssignmentFilter = Record<string, unknown>;
 
 @Injectable()
 export class ScheduleService {
-  private entries = [...scheduleEntries];
+  private readonly logger = new Logger(ScheduleService.name);
+  private readonly privilegedScheduleRoles = new Set<Role>([
+    Role.ADMIN,
+    Role.DISPATCHER,
+    Role.DEAN,
+    Role.RECTOR,
+    Role.PRESIDENT,
+  ]);
 
-  findAll() {
-    return this.entries.map((entry) => this.enrichEntry(entry));
+  constructor(
+    @InjectModel(ScheduleEntry.name)
+    private readonly scheduleEntryModel: Model<ScheduleEntryDocument>,
+    @InjectModel(CourseAssignment.name)
+    private readonly courseAssignmentModel: Model<CourseAssignmentDocument>,
+    @InjectModel(Classroom.name)
+    private readonly classroomModel: Model<Classroom>,
+    @InjectModel(User.name)
+    private readonly userModel: Model<UserDocument>,
+    private readonly notificationsService: NotificationsService,
+  ) {}
+
+  async findAll(query: ScheduleQueryDto = {}): Promise<ScheduleEntryDto[]> {
+    const filter = await this.buildScheduleFilter(query);
+    return this.findEntries(filter);
   }
 
-  findByGroup(groupId: string) {
-    const caIds = courseAssignments
-      .filter((ca) => ca.groupId === groupId)
-      .map((ca) => ca.id);
+  async findForUser(
+    user: AuthenticatedUser,
+    query: ScheduleQueryDto = {},
+  ): Promise<ScheduleEntryDto[]> {
+    if (this.privilegedScheduleRoles.has(user.role)) {
+      return this.findAll(query);
+    }
 
-    return this.entries
-      .filter((e) => caIds.includes(e.courseAssignmentId))
-      .map((entry) => this.enrichEntry(entry));
+    const scopedQuery = this.omitUserScopeQuery(query);
+    if (user.role === Role.STUDENT) {
+      return this.findByStudent(user.sub, scopedQuery);
+    }
+    if (user.role === Role.TEACHER || user.role === Role.DEPARTMENT_HEAD) {
+      return this.findByTeacher(user.sub, scopedQuery);
+    }
+
+    return [];
   }
 
-  findByTeacher(teacherId: string) {
-    const caIds = courseAssignments
-      .filter((ca) => ca.teacherId === teacherId)
-      .map((ca) => ca.id);
-
-    return this.entries
-      .filter((e) => caIds.includes(e.courseAssignmentId))
-      .map((entry) => this.enrichEntry(entry));
+  async findOne(id: string): Promise<ScheduleEntryDto> {
+    return this.getPopulatedEntryOrThrow(id);
   }
 
-  findByStudent(studentId: string) {
-    const profile = studentProfiles.find((p) => p.userId === studentId);
-    if (!profile) return [];
-    return this.findByGroup(profile.groupId);
+  async findOneForUser(
+    id: string,
+    user: AuthenticatedUser,
+  ): Promise<ScheduleEntryDto> {
+    const entry = await this.findOne(id);
+    if (this.privilegedScheduleRoles.has(user.role)) {
+      return entry;
+    }
+
+    const visibleEntries = await this.findForUser(user, { date: entry.date });
+    if (visibleEntries.some((visibleEntry) => visibleEntry.id === entry.id)) {
+      return entry;
+    }
+
+    throw new ForbiddenException('Немає доступу до цього запису розкладу');
   }
 
-  findByDate(date: string) {
-    return this.entries
-      .filter((e) => e.date === date)
-      .map((entry) => this.enrichEntry(entry));
+  async findByGroup(
+    groupId: string,
+    query: ScheduleQueryDto = {},
+  ): Promise<ScheduleEntryDto[]> {
+    return this.findAll({ ...query, groupId });
   }
 
-  create(dto: Omit<ScheduleEntry, 'id'>) {
-    const conflicts = this.checkConflicts(dto);
+  async findByTeacher(
+    teacherId: string,
+    query: ScheduleQueryDto = {},
+  ): Promise<ScheduleEntryDto[]> {
+    return this.findAll({ ...query, teacherId });
+  }
+
+  async findByStudent(
+    studentId: string,
+    query: ScheduleQueryDto = {},
+  ): Promise<ScheduleEntryDto[]> {
+    const student = await this.userModel
+      .findById(this.toObjectId(studentId))
+      .select('studentProfile.group')
+      .lean<{ studentProfile?: { group?: unknown } }>()
+      .exec();
+
+    const groupId = student?.studentProfile?.group
+      ? toId(student.studentProfile.group)
+      : undefined;
+
+    if (!groupId || !Types.ObjectId.isValid(groupId)) {
+      return [];
+    }
+
+    return this.findByGroup(groupId, query);
+  }
+
+  async findByDate(date: string): Promise<ScheduleEntryDto[]> {
+    return this.findAll({ date });
+  }
+
+  async create(dto: CreateScheduleEntryDto): Promise<ScheduleEntryDto> {
+    const payload = await this.normalizeCreatePayload(dto);
+    await this.assertNoConflicts(payload);
+
+    const created = await this.scheduleEntryModel.create({
+      courseAssignment: new Types.ObjectId(payload.courseAssignmentId),
+      classroom: payload.classroomId
+        ? new Types.ObjectId(payload.classroomId)
+        : null,
+      date: payload.date,
+      startTime: payload.startTime,
+      endTime: payload.endTime,
+      type: payload.type,
+      status: payload.status,
+    } as never);
+
+    const entry = await this.getPopulatedEntryOrThrow(toId(created._id));
+    await this.notifyScheduleChanged('created', entry);
+    return entry;
+  }
+
+  async update(
+    id: string,
+    dto: UpdateScheduleEntryDto,
+  ): Promise<ScheduleEntryDto> {
+    const entryId = this.toObjectId(id);
+    const [currentEntry, currentView] = await Promise.all([
+      this.scheduleEntryModel.findById(entryId).exec(),
+      this.getPopulatedEntryOrThrow(id),
+    ]);
+
+    if (!currentEntry) {
+      throw new NotFoundException('Запис розкладу не знайдено');
+    }
+
+    const payload = await this.normalizeUpdatePayload(currentEntry, dto);
+    await this.assertNoConflicts(payload, id);
+
+    currentEntry.set({
+      courseAssignment: new Types.ObjectId(payload.courseAssignmentId),
+      classroom: payload.classroomId
+        ? new Types.ObjectId(payload.classroomId)
+        : null,
+      date: payload.date,
+      startTime: payload.startTime,
+      endTime: payload.endTime,
+      type: payload.type,
+      status: payload.status,
+    });
+
+    await currentEntry.save();
+
+    const updatedEntry = await this.getPopulatedEntryOrThrow(id);
+    await this.notifyScheduleChanged('updated', updatedEntry, currentView);
+    return updatedEntry;
+  }
+
+  async delete(id: string): Promise<{ deleted: true }> {
+    const entryId = this.toObjectId(id);
+    const currentView = await this.getPopulatedEntryOrThrow(id);
+    const result = await this.scheduleEntryModel
+      .deleteOne({ _id: entryId })
+      .exec();
+
+    if (result.deletedCount === 0) {
+      throw new NotFoundException('Запис розкладу не знайдено');
+    }
+
+    await this.notifyScheduleChanged('deleted', currentView);
+    return { deleted: true };
+  }
+
+  async isClassroomUsed(classroomId: string): Promise<boolean> {
+    const count = await this.scheduleEntryModel
+      .countDocuments({
+        classroom: this.toObjectId(classroomId),
+        status: { $ne: ScheduleEntryStatus.CANCELLED },
+      })
+      .exec();
+
+    return count > 0;
+  }
+
+  async exportCsv(
+    user: AuthenticatedUser,
+    query: ScheduleQueryDto = {},
+  ): Promise<string> {
+    const entries = await this.findForUser(user, query);
+    const rows = [
+      [
+        'date',
+        'start_time',
+        'end_time',
+        'type',
+        'status',
+        'course_code',
+        'course_name',
+        'group',
+        'teacher',
+        'classroom',
+      ],
+      ...entries.map((entry) => [
+        entry.date,
+        entry.startTime,
+        entry.endTime,
+        entry.type,
+        entry.status,
+        entry.courseCode ?? '',
+        entry.courseName ?? '',
+        entry.groupCode ?? '',
+        entry.teacherName ?? '',
+        entry.classroom ?? '',
+      ]),
+    ];
+
+    return `\uFEFF${rows
+      .map((row) => row.map((value) => this.escapeCsv(value)).join(','))
+      .join('\n')}\n`;
+  }
+
+  private async findEntries(
+    filter: ScheduleFilter,
+  ): Promise<ScheduleEntryDto[]> {
+    const entries = await this.scheduleEntryModel
+      .find(filter as never)
+      .sort({ date: 1, startTime: 1, endTime: 1 })
+      .populate(this.courseAssignmentPopulate())
+      .populate({ path: 'classroom', select: 'building roomNumber type' })
+      .lean<ScheduleEntryLean[]>()
+      .exec();
+
+    return entries.map((entry) => this.formatEntry(entry));
+  }
+
+  private async getPopulatedEntryOrThrow(
+    id: string,
+  ): Promise<ScheduleEntryDto> {
+    const entry = await this.scheduleEntryModel
+      .findById(this.toObjectId(id))
+      .populate(this.courseAssignmentPopulate())
+      .populate({ path: 'classroom', select: 'building roomNumber type' })
+      .lean<ScheduleEntryLean>()
+      .exec();
+
+    if (!entry) {
+      throw new NotFoundException('Запис розкладу не знайдено');
+    }
+
+    return this.formatEntry(entry);
+  }
+
+  private async buildScheduleFilter(
+    query: ScheduleQueryDto,
+  ): Promise<ScheduleFilter> {
+    const filter: ScheduleFilter = {};
+
+    if (query.date) {
+      const range = this.getDayRange(this.normalizeDate(query.date));
+      filter.date = { $gte: range.start, $lt: range.end };
+    } else if (query.startDate || query.endDate) {
+      filter.date = this.buildDateRange(query.startDate, query.endDate);
+    }
+
+    if (query.status) {
+      filter.status = query.status;
+    }
+
+    if (query.groupId || query.teacherId) {
+      const assignmentIds = await this.findCourseAssignmentIds(query);
+      filter.courseAssignment =
+        assignmentIds.length > 0
+          ? { $in: assignmentIds.map((id) => new Types.ObjectId(id)) }
+          : { $in: [] };
+    }
+
+    return filter;
+  }
+
+  private async findCourseAssignmentIds(
+    query: ScheduleQueryDto,
+  ): Promise<string[]> {
+    const filter: CourseAssignmentFilter = {};
+
+    if (query.groupId) {
+      filter.group = this.toObjectId(query.groupId);
+    }
+    if (query.teacherId) {
+      filter.teacher = this.toObjectId(query.teacherId);
+    }
+
+    const assignments = await this.courseAssignmentModel
+      .find(filter as never)
+      .select('_id')
+      .lean<Array<{ _id: unknown }>>()
+      .exec();
+
+    return assignments.map((assignment) => toId(assignment._id));
+  }
+
+  private async normalizeCreatePayload(
+    dto: CreateScheduleEntryDto,
+  ): Promise<NormalizedSchedulePayload> {
+    return this.normalizePayload({
+      courseAssignmentId: dto.courseAssignmentId,
+      classroomId: dto.classroomId,
+      date: dto.date,
+      startTime: dto.startTime,
+      endTime: dto.endTime,
+      type: dto.type,
+      status: dto.status ?? ScheduleEntryStatus.SCHEDULED,
+    });
+  }
+
+  private async normalizeUpdatePayload(
+    currentEntry: ScheduleEntryDocument,
+    dto: UpdateScheduleEntryDto,
+  ): Promise<NormalizedSchedulePayload> {
+    const currentClassroomId = currentEntry.classroom
+      ? toId(currentEntry.classroom)
+      : undefined;
+
+    return this.normalizePayload({
+      courseAssignmentId:
+        dto.courseAssignmentId ?? toId(currentEntry.courseAssignment),
+      classroomId:
+        dto.classroomId !== undefined ? dto.classroomId : currentClassroomId,
+      date: dto.date ?? this.formatDate(currentEntry.date),
+      startTime: dto.startTime ?? currentEntry.startTime,
+      endTime: dto.endTime ?? currentEntry.endTime,
+      type: dto.type ?? currentEntry.type,
+      status: dto.status ?? currentEntry.status,
+    });
+  }
+
+  private async normalizePayload(payload: {
+    courseAssignmentId: string;
+    classroomId?: string;
+    date: string;
+    startTime: string;
+    endTime: string;
+    type: ScheduleEntryType;
+    status: ScheduleEntryStatus;
+  }): Promise<NormalizedSchedulePayload> {
+    if (payload.startTime >= payload.endTime) {
+      throw new BadRequestException(
+        'Час завершення повинен бути пізніше часу початку',
+      );
+    }
+
+    const date = this.normalizeDate(payload.date);
+    const [assignment] = await Promise.all([
+      this.getCourseAssignmentOrThrow(payload.courseAssignmentId),
+      this.assertClassroomExists(payload.classroomId),
+    ]);
+
+    return {
+      ...payload,
+      date,
+      dateString: this.formatDate(date),
+      classroomId: payload.classroomId || undefined,
+      assignment,
+    };
+  }
+
+  private async assertNoConflicts(
+    payload: NormalizedSchedulePayload,
+    excludeEntryId?: string,
+  ): Promise<void> {
+    if (payload.status === ScheduleEntryStatus.CANCELLED) {
+      return;
+    }
+
+    const range = this.getDayRange(payload.date);
+    const filter: ScheduleFilter = {
+      date: { $gte: range.start, $lt: range.end },
+      status: { $ne: ScheduleEntryStatus.CANCELLED },
+      startTime: { $lt: payload.endTime },
+      endTime: { $gt: payload.startTime },
+    };
+
+    if (excludeEntryId) {
+      filter._id = { $ne: this.toObjectId(excludeEntryId) };
+    }
+
+    const overlappingEntries = await this.scheduleEntryModel
+      .find(filter as never)
+      .populate(this.courseAssignmentPopulate())
+      .populate({ path: 'classroom', select: 'building roomNumber type' })
+      .lean<ScheduleEntryLean[]>()
+      .exec();
+
+    const conflicts = this.collectConflicts(payload, overlappingEntries);
+
     if (conflicts.length > 0) {
-      throw new BadRequestException({
+      throw new ConflictException({
         message: 'Конфлікт розкладу',
         conflicts,
       });
     }
-
-    const entry: ScheduleEntry = { id: `sch-${Date.now()}`, ...dto };
-    this.entries.push(entry);
-    return this.enrichEntry(entry);
   }
 
-  update(id: string, dto: Partial<ScheduleEntry>) {
-    const idx = this.entries.findIndex((e) => e.id === id);
-    if (idx === -1) throw new NotFoundException('Запис розкладу не знайдено');
+  private collectConflicts(
+    payload: NormalizedSchedulePayload,
+    overlappingEntries: ScheduleEntryLean[],
+  ): ScheduleConflict[] {
+    const conflicts: ScheduleConflict[] = [];
+    const teacherId = this.idToString(payload.assignment.teacher);
+    const groupId = this.idToString(payload.assignment.group);
 
-    this.entries[idx] = { ...this.entries[idx], ...dto };
-    return this.enrichEntry(this.entries[idx]);
-  }
+    for (const entry of overlappingEntries) {
+      const assignment = this.asCourseAssignment(entry.courseAssignment);
+      const conflictBase = {
+        entryId: this.idToString(entry),
+        date: this.formatDate(entry.date),
+        startTime: entry.startTime,
+        endTime: entry.endTime,
+      };
 
-  delete(id: string) {
-    const idx = this.entries.findIndex((e) => e.id === id);
-    if (idx === -1) throw new NotFoundException('Запис розкладу не знайдено');
-    this.entries.splice(idx, 1);
-    return { deleted: true };
-  }
-
-  isClassroomUsed(classroomId: string): boolean {
-    return this.entries.some(
-      (entry) =>
-        entry.classroomId === classroomId && entry.status !== 'cancelled',
-    );
-  }
-
-  private checkConflicts(dto: Omit<ScheduleEntry, 'id'>) {
-    const conflicts: string[] = [];
-    const ca = courseAssignments.find((c) => c.id === dto.courseAssignmentId);
-    if (!ca) return conflicts;
-
-    for (const entry of this.entries) {
-      if (entry.date !== dto.date || entry.status === 'cancelled') continue;
-      if (entry.startTime >= dto.endTime || entry.endTime <= dto.startTime)
-        continue;
-
-      const entryCa = courseAssignments.find(
-        (c) => c.id === entry.courseAssignmentId,
-      );
-      if (!entryCa) continue;
-
-      if (entryCa.teacherId === ca.teacherId) {
-        conflicts.push(
-          `Викладач зайнятий: ${entry.startTime}-${entry.endTime}`,
-        );
+      if (teacherId && this.idToString(assignment?.teacher) === teacherId) {
+        conflicts.push({
+          ...conflictBase,
+          type: 'teacher',
+          message: `Викладач зайнятий: ${entry.startTime}-${entry.endTime}`,
+        });
       }
-      if (dto.classroomId && entry.classroomId === dto.classroomId) {
-        conflicts.push(
-          `Аудиторія зайнята: ${entry.startTime}-${entry.endTime}`,
-        );
+
+      if (
+        payload.classroomId &&
+        this.idToString(entry.classroom) === payload.classroomId
+      ) {
+        conflicts.push({
+          ...conflictBase,
+          type: 'classroom',
+          message: `Аудиторія зайнята: ${entry.startTime}-${entry.endTime}`,
+        });
       }
-      if (entryCa.groupId === ca.groupId) {
-        conflicts.push(`Група зайнята: ${entry.startTime}-${entry.endTime}`);
+
+      if (groupId && this.idToString(assignment?.group) === groupId) {
+        conflicts.push({
+          ...conflictBase,
+          type: 'group',
+          message: `Група зайнята: ${entry.startTime}-${entry.endTime}`,
+        });
       }
     }
 
     return conflicts;
   }
 
-  private enrichEntry(entry: ScheduleEntry) {
-    const ca = courseAssignments.find((c) => c.id === entry.courseAssignmentId);
-    const course = ca ? courses.find((c) => c.id === ca.courseId) : null;
-    const group = ca ? groups.find((g) => g.id === ca.groupId) : null;
-    const classroom = entry.classroomId
-      ? classrooms.find((r) => r.id === entry.classroomId)
-      : null;
+  private async getCourseAssignmentOrThrow(
+    id: string,
+  ): Promise<CourseAssignmentLean> {
+    const assignment = await this.courseAssignmentModel
+      .findById(this.toObjectId(id))
+      .populate(this.courseAssignmentPopulate().populate)
+      .lean<CourseAssignmentLean>()
+      .exec();
+
+    if (!assignment) {
+      throw new NotFoundException('Призначення курсу не знайдено');
+    }
+
+    return assignment;
+  }
+
+  private async assertClassroomExists(classroomId?: string): Promise<void> {
+    if (!classroomId) {
+      return;
+    }
+
+    const classroomExists = await this.classroomModel
+      .exists({ _id: this.toObjectId(classroomId) })
+      .exec();
+
+    if (!classroomExists) {
+      throw new NotFoundException('Аудиторію не знайдено');
+    }
+  }
+
+  private async notifyScheduleChanged(
+    action: ScheduleChangeAction,
+    entry: ScheduleEntryDto,
+    previousEntry?: ScheduleEntryDto,
+  ): Promise<void> {
+    try {
+      const recipientIds = await this.resolveNotificationRecipients([
+        entry.courseAssignmentId,
+        previousEntry?.courseAssignmentId,
+      ]);
+
+      if (recipientIds.length === 0) {
+        this.logger.warn(
+          `Schedule notification skipped: no recipients for entry ${entry.id}`,
+        );
+        return;
+      }
+
+      await this.notificationsService.createMany(
+        recipientIds.map((userId) => ({
+          userId,
+          title: this.getNotificationTitle(action),
+          message: this.getNotificationMessage(action, entry, previousEntry),
+          type: NotificationType.SCHEDULE_CHANGE,
+        })),
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'unknown error';
+      this.logger.warn(
+        `Schedule notification was not created for ${entry.id}: ${message}`,
+      );
+    }
+  }
+
+  private async resolveNotificationRecipients(
+    courseAssignmentIds: Array<string | undefined>,
+  ): Promise<string[]> {
+    const objectIds = [
+      ...new Set(
+        courseAssignmentIds
+          .filter((id): id is string => Boolean(id))
+          .filter((id) => Types.ObjectId.isValid(id)),
+      ),
+    ].map((id) => new Types.ObjectId(id));
+
+    if (objectIds.length === 0) {
+      return [];
+    }
+
+    const assignments = await this.courseAssignmentModel
+      .find({ _id: { $in: objectIds } } as never)
+      .select('teacher group')
+      .lean<CourseAssignmentLean[]>()
+      .exec();
+
+    const teacherIds = assignments
+      .map((assignment) => this.idToString(assignment.teacher))
+      .filter(Boolean);
+    const groupIds = [
+      ...new Set(
+        assignments
+          .map((assignment) => this.idToString(assignment.group))
+          .filter((id) => Types.ObjectId.isValid(id)),
+      ),
+    ].map((id) => new Types.ObjectId(id));
+
+    if (groupIds.length === 0) {
+      return [...new Set(teacherIds)];
+    }
+
+    const students = await this.userModel
+      .find({
+        status: 'active',
+        'studentProfile.group': { $in: groupIds },
+      } as never)
+      .select('_id')
+      .lean<Array<{ _id: unknown }>>()
+      .exec();
+
+    const studentIds = students.map((student) => toId(student._id));
+    return [...new Set([...teacherIds, ...studentIds])];
+  }
+
+  private getNotificationTitle(action: ScheduleChangeAction): string {
+    if (action === 'created') return 'Нове заняття в розкладі';
+    if (action === 'deleted') return 'Заняття видалено з розкладу';
+    return 'Зміна розкладу';
+  }
+
+  private getNotificationMessage(
+    action: ScheduleChangeAction,
+    entry: ScheduleEntryDto,
+    previousEntry?: ScheduleEntryDto,
+  ): string {
+    const course = entry.courseName ?? entry.courseCode ?? 'Заняття';
+    const nextSlot = `${entry.date} ${entry.startTime}-${entry.endTime}`;
+
+    if (action === 'created') {
+      return `${course}: додано заняття ${nextSlot}.`;
+    }
+    if (action === 'deleted') {
+      return `${course}: заняття ${nextSlot} видалено з розкладу.`;
+    }
+
+    const previousSlot = previousEntry
+      ? `${previousEntry.date} ${previousEntry.startTime}-${previousEntry.endTime}`
+      : 'попередній час';
+
+    return `${course}: розклад змінено з ${previousSlot} на ${nextSlot}.`;
+  }
+
+  private formatEntry(entry: ScheduleEntryLean): ScheduleEntryDto {
+    const assignment = this.asCourseAssignment(entry.courseAssignment);
+    const course = this.asCourse(assignment?.course);
+    const group = this.asGroup(assignment?.group);
+    const teacher = this.asUser(assignment?.teacher);
+    const classroom = this.asClassroom(entry.classroom);
+    const teacherName = this.formatPersonName(teacher);
 
     return {
-      ...entry,
+      id: this.idToString(entry),
+      courseAssignmentId: this.idToString(assignment),
+      classroomId: this.idToString(classroom) || undefined,
+      date: this.formatDate(entry.date),
+      startTime: entry.startTime,
+      endTime: entry.endTime,
+      type: entry.type,
+      status: entry.status,
       courseName: course?.name,
       courseCode: course?.code,
       groupCode: group?.code,
-      teacherId: ca?.teacherId,
+      teacherId: this.idToString(teacher) || undefined,
+      teacherName,
       classroom: classroom
-        ? `${classroom.building}, ауд. ${classroom.roomNumber}`
+        ? `${classroom.building ?? ''}, ауд. ${
+            classroom.roomNumber ?? ''
+          }`.trim()
         : 'Онлайн',
+      createdAt: entry.createdAt?.toISOString(),
+      updatedAt: entry.updatedAt?.toISOString(),
     };
+  }
+
+  private courseAssignmentPopulate() {
+    return {
+      path: 'courseAssignment',
+      populate: [
+        { path: 'course', select: 'name code' },
+        { path: 'group', select: 'code' },
+        { path: 'teacher', select: 'firstName lastName middleName' },
+      ],
+    };
+  }
+
+  private asCourseAssignment(
+    value: CourseAssignmentLean | EntityRef | undefined,
+  ): CourseAssignmentLean | undefined {
+    return this.isObjectRecord(value) ? value : undefined;
+  }
+
+  private asCourse(
+    value: CourseLean | EntityRef | undefined,
+  ): CourseLean | undefined {
+    return this.isObjectRecord(value) ? value : undefined;
+  }
+
+  private asGroup(
+    value: GroupLean | EntityRef | undefined,
+  ): GroupLean | undefined {
+    return this.isObjectRecord(value) ? value : undefined;
+  }
+
+  private asUser(
+    value: UserLean | EntityRef | undefined,
+  ): UserLean | undefined {
+    return this.isObjectRecord(value) ? value : undefined;
+  }
+
+  private asClassroom(
+    value: ClassroomLean | EntityRef | null | undefined,
+  ): ClassroomLean | undefined {
+    return this.isObjectRecord(value) ? value : undefined;
+  }
+
+  private isObjectRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+  }
+
+  private normalizeDate(value: string): Date {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+      throw new BadRequestException('Дата повинна мати формат YYYY-MM-DD');
+    }
+
+    const date = new Date(`${value}T00:00:00.000Z`);
+    if (Number.isNaN(date.getTime()) || this.formatDate(date) !== value) {
+      throw new BadRequestException('Некоректна дата');
+    }
+
+    return date;
+  }
+
+  private buildDateRange(
+    startDate?: string,
+    endDate?: string,
+  ): { $gte?: Date; $lt?: Date } {
+    const range: { $gte?: Date; $lt?: Date } = {};
+
+    if (startDate) {
+      range.$gte = this.normalizeDate(startDate);
+    }
+    if (endDate) {
+      range.$lt = this.getDayRange(this.normalizeDate(endDate)).end;
+    }
+    if (range.$gte && range.$lt && range.$gte >= range.$lt) {
+      throw new BadRequestException(
+        'Дата завершення повинна бути не раніше дати початку',
+      );
+    }
+
+    return range;
+  }
+
+  private getDayRange(date: Date): { start: Date; end: Date } {
+    const start = new Date(
+      Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()),
+    );
+    const end = new Date(start);
+    end.setUTCDate(end.getUTCDate() + 1);
+    return { start, end };
+  }
+
+  private formatDate(value: Date | string): string {
+    if (typeof value === 'string') {
+      return value.slice(0, 10);
+    }
+    return value.toISOString().slice(0, 10);
+  }
+
+  private toObjectId(id: string): Types.ObjectId {
+    if (!Types.ObjectId.isValid(id)) {
+      throw new BadRequestException('Некоректний ID');
+    }
+    return new Types.ObjectId(id);
+  }
+
+  private idToString(value: unknown): string {
+    if (value === null || value === undefined) {
+      return '';
+    }
+    return toId(value);
+  }
+
+  private formatPersonName(person?: UserLean): string | undefined {
+    if (!person) {
+      return undefined;
+    }
+
+    const name = [person.lastName, person.firstName, person.middleName]
+      .filter(Boolean)
+      .join(' ');
+
+    return name || undefined;
+  }
+
+  private omitUserScopeQuery(query: ScheduleQueryDto): ScheduleQueryDto {
+    return {
+      date: query.date,
+      startDate: query.startDate,
+      endDate: query.endDate,
+      status: query.status,
+    };
+  }
+
+  private escapeCsv(value: string): string {
+    const safeValue = /^[=+\-@]/.test(value) ? `'${value}` : value;
+    if (/[",\n\r]/.test(safeValue)) {
+      return `"${safeValue.replace(/"/g, '""')}"`;
+    }
+    return safeValue;
   }
 }

--- a/server/src/schedule/schemas/index.ts
+++ b/server/src/schedule/schemas/index.ts
@@ -1,0 +1,1 @@
+export * from './schedule-entry.schema';

--- a/server/src/schedule/schemas/schedule-entry.schema.ts
+++ b/server/src/schedule/schemas/schedule-entry.schema.ts
@@ -1,0 +1,87 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document, Schema as MongooseSchema } from 'mongoose';
+import { CourseAssignment } from '../../courses/schemas';
+import { Classroom } from '../../references/schemas';
+
+export enum ScheduleEntryType {
+  LECTURE = 'lecture',
+  SEMINAR = 'seminar',
+  LAB = 'lab',
+  EXAM = 'exam',
+  CONSULTATION = 'consultation',
+}
+
+export enum ScheduleEntryStatus {
+  SCHEDULED = 'scheduled',
+  CANCELLED = 'cancelled',
+  RESCHEDULED = 'rescheduled',
+}
+
+export type ScheduleEntryDocument = ScheduleEntry & Document;
+
+@Schema({ timestamps: true })
+export class ScheduleEntry {
+  _id: MongooseSchema.Types.ObjectId;
+
+  @Prop({
+    type: MongooseSchema.Types.ObjectId,
+    ref: CourseAssignment.name,
+    required: true,
+    index: true,
+  })
+  courseAssignment: MongooseSchema.Types.ObjectId | CourseAssignment;
+
+  @Prop({
+    type: MongooseSchema.Types.ObjectId,
+    ref: Classroom.name,
+    default: null,
+    index: true,
+  })
+  classroom?: MongooseSchema.Types.ObjectId | Classroom | null;
+
+  @Prop({ type: Date, required: true, index: true })
+  date: Date;
+
+  @Prop({ required: true, match: /^([01]\d|2[0-3]):[0-5]\d$/ })
+  startTime: string;
+
+  @Prop({ required: true, match: /^([01]\d|2[0-3]):[0-5]\d$/ })
+  endTime: string;
+
+  @Prop({
+    type: String,
+    enum: Object.values(ScheduleEntryType),
+    required: true,
+  })
+  type: ScheduleEntryType;
+
+  @Prop({
+    type: String,
+    enum: Object.values(ScheduleEntryStatus),
+    default: ScheduleEntryStatus.SCHEDULED,
+    required: true,
+    index: true,
+  })
+  status: ScheduleEntryStatus;
+
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export const ScheduleEntrySchema = SchemaFactory.createForClass(ScheduleEntry);
+
+ScheduleEntrySchema.index({ date: 1, startTime: 1, endTime: 1 });
+ScheduleEntrySchema.index({
+  courseAssignment: 1,
+  date: 1,
+  startTime: 1,
+});
+ScheduleEntrySchema.index(
+  { classroom: 1, date: 1, startTime: 1, endTime: 1 },
+  {
+    partialFilterExpression: {
+      classroom: { $type: 'objectId' },
+      status: { $ne: ScheduleEntryStatus.CANCELLED },
+    },
+  },
+);

--- a/server/src/seed/seed.module.ts
+++ b/server/src/seed/seed.module.ts
@@ -23,6 +23,7 @@ import {
   ClassroomSeeder,
   CourseSeeder,
   CourseAssignmentSeeder,
+  ScheduleEntrySeeder,
   GradeSeeder,
   AssignmentSeeder,
   MaterialSeeder,
@@ -39,6 +40,7 @@ import {
   Material,
   MaterialSchema,
 } from '../courses/schemas';
+import { ScheduleEntry, ScheduleEntrySchema } from '../schedule/schemas';
 
 @Module({
   imports: [
@@ -51,6 +53,7 @@ import {
       { name: Classroom.name, schema: ClassroomSchema },
       { name: Course.name, schema: CourseSchema },
       { name: CourseAssignment.name, schema: CourseAssignmentSchema },
+      { name: ScheduleEntry.name, schema: ScheduleEntrySchema },
       { name: Grade.name, schema: GradeSchema },
       { name: Assignment.name, schema: AssignmentSchema },
       { name: Material.name, schema: MaterialSchema },
@@ -66,6 +69,7 @@ import {
     ClassroomSeeder,
     CourseSeeder,
     CourseAssignmentSeeder,
+    ScheduleEntrySeeder,
     GradeSeeder,
     AssignmentSeeder,
     MaterialSeeder,

--- a/server/src/seed/seed.service.ts
+++ b/server/src/seed/seed.service.ts
@@ -8,6 +8,7 @@ import {
   ClassroomSeeder,
   CourseSeeder,
   CourseAssignmentSeeder,
+  ScheduleEntrySeeder,
   GradeSeeder,
   AssignmentSeeder,
   MaterialSeeder,
@@ -26,6 +27,7 @@ export class SeedService implements OnModuleInit {
     private readonly groupSeeder: GroupSeeder,
     private readonly courseSeeder: CourseSeeder,
     private readonly courseAssignmentSeeder: CourseAssignmentSeeder,
+    private readonly scheduleEntrySeeder: ScheduleEntrySeeder,
     private readonly gradeSeeder: GradeSeeder,
     private readonly assignmentSeeder: AssignmentSeeder,
     private readonly materialSeeder: MaterialSeeder,
@@ -48,6 +50,7 @@ export class SeedService implements OnModuleInit {
       await this.groupSeeder.seed();
       await this.courseSeeder.seed();
       await this.courseAssignmentSeeder.seed();
+      await this.scheduleEntrySeeder.seed();
       await this.gradeSeeder.seed();
       await this.assignmentSeeder.seed();
       await this.materialSeeder.seed();

--- a/server/src/seed/seeders/index.ts
+++ b/server/src/seed/seeders/index.ts
@@ -6,6 +6,7 @@ export * from './specialty.seeder';
 export * from './classroom.seeder';
 export * from './course.seeder';
 export * from './course-assignment.seeder';
+export * from './schedule-entry.seeder';
 export * from './grade.seeder';
 export * from './assignment.seeder';
 export * from './material.seeder';

--- a/server/src/seed/seeders/schedule-entry.seeder.ts
+++ b/server/src/seed/seeders/schedule-entry.seeder.ts
@@ -1,0 +1,37 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { scheduleEntries } from '../../common/mock-data';
+import { ScheduleEntry } from '../../schedule/schemas';
+
+@Injectable()
+export class ScheduleEntrySeeder {
+  private readonly logger = new Logger(ScheduleEntrySeeder.name);
+
+  constructor(
+    @InjectModel(ScheduleEntry.name)
+    private readonly scheduleEntryModel: Model<ScheduleEntry>,
+  ) {}
+
+  async seed(): Promise<void> {
+    const count = await this.scheduleEntryModel.countDocuments();
+    if (count > 0) {
+      this.logger.log('Schedule entries already exist. Skipping seeding.');
+      return;
+    }
+
+    const data = scheduleEntries.map((entry) => ({
+      _id: entry.id,
+      courseAssignment: entry.courseAssignmentId,
+      classroom: entry.classroomId ?? null,
+      date: new Date(`${entry.date}T00:00:00.000Z`),
+      startTime: entry.startTime,
+      endTime: entry.endTime,
+      type: entry.type,
+      status: entry.status,
+    }));
+
+    await this.scheduleEntryModel.insertMany(data);
+    this.logger.log(`Seeded ${data.length} schedule entries.`);
+  }
+}


### PR DESCRIPTION
## Summary

Completes the ScheduleModule scope from #36 (#37, #38, #39).

- Reworked ScheduleModule from in-memory mock data to MongoDB-backed schedule entries.
- Added validated schedule DTOs, Mongoose schema, indexes, CRUD endpoints, scoped reads and single-entry access checks.
- Added conflict detection for overlapping teacher, classroom and group schedule entries.
- Added automatic `schedule_change` notifications on schedule create/update/delete.
- Added `/api/schedule/export` CSV export with spreadsheet formula injection protection.
- Added schedule seeding from existing mock schedule data.
- Updated classroom deletion integrity checks to use active persisted schedule entries.
- Added unit tests for schedule conflicts, notifications, and CSV export.

## Security & Quality

- Non-privileged users can only access their own schedule scope.
- Schedule IDs, dates, times, course assignments and classrooms are validated before writes.
- Conflict responses return `409 Conflict` with structured conflict details.
- CSV output is escaped and formula-like values are neutralized.
- Notification failures are logged without breaking schedule writes.

## Verification

- `npm run build` in `server` passed.
- `npm run lint` in `server` passed.
- `npm test -- --runInBand` in `server` passed.
- `npm audit --audit-level=high` in `server` passed.
- `npm run lint` in `client` passed.
- `npm run build` in `client` passed.
- `npm audit --audit-level=high` in `client` passed.

##

Closed #36
Closed #37
Closed #38
Closed #39
