### PR TITLE
fix(repo): add shell shebang to Husky pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,2 @@
+#!/usr/bin/env sh
 npm run precommit


### PR DESCRIPTION
Add a POSIX shell shebang to the Husky pre-commit hook for better direct execution compatibility while keeping the Husky v9 hook format without the deprecated husky.sh loader.