### PR TITLE
ci: update GitHub Actions runtime actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
           cache: npm
@@ -36,10 +36,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
           cache: npm
@@ -72,10 +72,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
           cache: npm

--- a/server/src/audit-log/audit-log.service.spec.ts
+++ b/server/src/audit-log/audit-log.service.spec.ts
@@ -1,3 +1,4 @@
+import { Logger } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getModelToken } from '@nestjs/mongoose';
 import { AuditLogService } from './audit-log.service';
@@ -6,6 +7,8 @@ import { AuditLog } from './schemas/audit-log.schema';
 
 describe('AuditLogService', () => {
   let service: AuditLogService;
+  let loggerErrorSpy: jest.SpyInstance;
+  let loggerLogSpy: jest.SpyInstance;
   const auditModel = {
     create: jest.fn().mockResolvedValue({}),
     find: jest.fn(),
@@ -14,6 +17,8 @@ describe('AuditLogService', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
+    loggerErrorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation();
+    loggerLogSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation();
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -26,6 +31,11 @@ describe('AuditLogService', () => {
     }).compile();
 
     service = module.get<AuditLogService>(AuditLogService);
+  });
+
+  afterEach(() => {
+    loggerErrorSpy.mockRestore();
+    loggerLogSpy.mockRestore();
   });
 
   it('should be defined', () => {


### PR DESCRIPTION
Upgrade checkout and setup-node to v6 to remove Node.js 20 action runtime deprecation warnings, and silence expected audit-log error output in unit tests so CI logs stay clean.