### PR TITLE
fix(client): count only required survey questions in survey progress

### DIFF
--- a/client/src/i18n.ts
+++ b/client/src/i18n.ts
@@ -342,6 +342,8 @@ const resources = {
 
       'surveys.player.progress': 'Прогрес',
       'surveys.player.answered': 'відповідей',
+      'surveys.player.requiredAnswered': 'обовʼязкових відповідей',
+      'surveys.player.noRequiredQuestions': 'Обовʼязкових питань немає',
       'surveys.player.textPlaceholder': 'Напишіть відповідь...',
       'surveys.player.requiredError':
         'Заповніть усі обовʼязкові питання перед відправкою.',
@@ -762,6 +764,8 @@ const resources = {
 
       'surveys.player.progress': 'Progress',
       'surveys.player.answered': 'answered',
+      'surveys.player.requiredAnswered': 'required answered',
+      'surveys.player.noRequiredQuestions': 'No required questions',
       'surveys.player.textPlaceholder': 'Write your answer...',
       'surveys.player.requiredError':
         'Answer all required questions before submitting.',

--- a/client/src/pages/surveys/SurveyPlayerPage.tsx
+++ b/client/src/pages/surveys/SurveyPlayerPage.tsx
@@ -170,16 +170,32 @@ export default function SurveyPlayerPage() {
   }, [responseQuery.data?.response?.answers]);
 
   const completed = Boolean(responseQuery.data?.completed);
-  const answeredCount = completed
+  const requiredQuestions = useMemo(
+    () => sortedQuestions.filter((question) => question.required),
+    [sortedQuestions],
+  );
+  const requiredAnsweredCount = requiredQuestions.filter((question) =>
+    isAnswerProvided(answers[question.id]),
+  ).length;
+  const progressAnsweredCount = completed
     ? sortedQuestions.length
-    : sortedQuestions.filter(
-        (question) =>
-          !question.required || isAnswerProvided(answers[question.id]),
-      ).length;
-  const progress =
-    sortedQuestions.length === 0
+    : requiredAnsweredCount;
+  const progressTotalCount = completed
+    ? sortedQuestions.length
+    : requiredQuestions.length;
+  const progress = completed
+    ? 100
+    : progressTotalCount === 0
       ? 0
-      : Math.round((answeredCount / sortedQuestions.length) * 100);
+      : Math.round((progressAnsweredCount / progressTotalCount) * 100);
+  const progressCaption =
+    !completed && progressTotalCount === 0
+      ? t('surveys.player.noRequiredQuestions')
+      : `${progressAnsweredCount} / ${progressTotalCount} ${
+          completed
+            ? t('surveys.player.answered')
+            : t('surveys.player.requiredAnswered')
+        }`;
 
   useEffect(() => {
     if (!successMessage) return undefined;
@@ -327,8 +343,7 @@ export default function SurveyPlayerPage() {
               />
             </div>
             <p className="mt-2 text-xs text-slate-500">
-              {answeredCount} / {sortedQuestions.length}{' '}
-              {t('surveys.player.answered')}
+              {progressCaption}
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Updates survey progress calculation before submission to count only required questions.
- Keeps completed surveys at 100% progress after submission.
- Adds localized labels for required-answer progress and surveys without required questions.

## Testing
- `client`: `npm run lint`
- `client`: `npm run build`