### PR TITLE
fix(surveys): prevent duplicate survey publish notifications

### DIFF
--- a/server/src/surveys/surveys.service.spec.ts
+++ b/server/src/surveys/surveys.service.spec.ts
@@ -84,7 +84,7 @@ describe('SurveysService', () => {
     Pick<CoursesService, 'isUserAssignedToCourseTargets'>
   >;
   let notificationsService: jest.Mocked<
-    Pick<NotificationsService, 'createMany'>
+    Pick<NotificationsService, 'create' | 'createMany'>
   >;
 
   const userId = new Types.ObjectId('6622b2a00f3a22d5b625d172');
@@ -136,6 +136,7 @@ describe('SurveysService', () => {
       isUserAssignedToCourseTargets: jest.fn().mockResolvedValue(false),
     };
     notificationsService = {
+      create: jest.fn(),
       createMany: jest.fn(),
     };
 
@@ -270,7 +271,7 @@ describe('SurveysService', () => {
     );
   });
 
-  it('creates new_survey notification on publish', async () => {
+  it('creates one broadcast new_survey notification for all users on publish', async () => {
     const draftSurvey = createSurveyDoc({
       status: SurveyStatus.DRAFT,
       startDate: new Date('2099-01-01T00:00:00.000Z'),
@@ -291,16 +292,48 @@ describe('SurveysService', () => {
     });
 
     expect(draftSurvey.startDate?.getTime()).toBeLessThanOrEqual(Date.now());
+    expect(notificationsService.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: NotificationType.NEW_SURVEY,
+        title: 'Нове опитування',
+        targetType: 'all',
+        actionUrl: `/surveys/${draftSurvey._id.toString()}`,
+        entityType: 'survey',
+        entityId: draftSurvey._id.toString(),
+      }),
+    );
+    expect(notificationsService.createMany).not.toHaveBeenCalled();
+  });
+
+  it('creates one new_survey notification per target group on publish', async () => {
+    const groupIds = ['6622b2a00f3a22d5b625d174', '6622b2a00f3a22d5b625d175'];
+    const draftSurvey = createSurveyDoc({
+      status: SurveyStatus.DRAFT,
+      targetType: SurveyTargetType.GROUPS,
+      targetIds: groupIds,
+    });
+    draftSurvey.save = jest.fn().mockResolvedValue(draftSurvey);
+
+    surveyModel.findById.mockReturnValueOnce(execQuery(draftSurvey));
+    await service.publish(draftSurvey._id.toString(), {
+      sub: draftSurvey.createdBy.toString(),
+      login: 'dean',
+      role: Role.DEAN,
+    });
+
+    expect(notificationsService.create).not.toHaveBeenCalled();
     expect(notificationsService.createMany).toHaveBeenCalledWith(
-      expect.arrayContaining([
-        expect.objectContaining({
-          type: NotificationType.NEW_SURVEY,
-          title: 'Нове опитування',
-          actionUrl: `/surveys/${draftSurvey._id.toString()}`,
-          entityType: 'survey',
-          entityId: draftSurvey._id.toString(),
-        }),
-      ]),
+      groupIds.map((groupId) => ({
+        type: NotificationType.NEW_SURVEY,
+        title: 'Нове опитування',
+        message: draftSurvey.title,
+        important: true,
+        targetType: 'group',
+        groupId,
+        actionUrl: `/surveys/${draftSurvey._id.toString()}`,
+        entityType: 'survey',
+        entityId: draftSurvey._id.toString(),
+      })),
     );
   });
 });

--- a/server/src/surveys/surveys.service.ts
+++ b/server/src/surveys/surveys.service.ts
@@ -1119,7 +1119,6 @@ export class SurveysService {
 
   private async notifySurveyPublished(survey: SurveyDocument): Promise<void> {
     try {
-      const recipients = await this.resolveNotificationRecipients(survey);
       const surveyId = this.idToString(survey._id);
       const payload = {
         title: 'Нове опитування',
@@ -1131,6 +1130,26 @@ export class SurveysService {
         important: true,
       };
 
+      if (survey.targetType === SurveyTargetType.ALL) {
+        await this.notificationsService.create({
+          ...payload,
+          targetType: 'all',
+        });
+        return;
+      }
+
+      if (survey.targetType === SurveyTargetType.GROUPS) {
+        await this.notificationsService.createMany(
+          survey.targetIds.map((groupId) => ({
+            ...payload,
+            targetType: 'group',
+            groupId,
+          })),
+        );
+        return;
+      }
+
+      const recipients = await this.resolveNotificationRecipients(survey);
       if (recipients.length === 0) {
         this.logger.warn(
           `Survey notification skipped: no recipients for survey ${this.idToString(survey._id)}`,


### PR DESCRIPTION
## Summary
- Prevents survey publish notifications from being duplicated per recipient for all-user audiences.
- Creates a single broadcast notification for `targetType=all`.
- Creates one group notification per target group for `targetType=groups`.
- Keeps recipient-specific notifications only for course-targeted surveys.
- Adds unit coverage for all-user and group-targeted survey publish notifications.

## Testing
- `server`: `npm run lint:check`
- `server`: `npm run build`
- `server`: `npm test`