### PR TITLE
feat(auth): add httpOnly cookie sessions and CSRF protection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,16 @@ CLIENT_URL=http://localhost:5173
 JWT_SECRET=campus-secret-key-change-in-production
 JWT_EXPIRES_IN=15m
 JWT_REFRESH_EXPIRES_IN=7d
+AUTH_ACCESS_COOKIE_NAME=campus_access_token
+AUTH_REFRESH_COOKIE_NAME=campus_refresh_token
+AUTH_ACCESS_COOKIE_PATH=/api
+AUTH_REFRESH_COOKIE_PATH=/api/auth
+AUTH_CSRF_COOKIE_NAME=campus_csrf_token
+AUTH_CSRF_COOKIE_PATH=/
+AUTH_CSRF_HEADER_NAME=x-csrf-token
+AUTH_COOKIE_SAMESITE=strict
+# Local HTTP development: false. HTTPS/dev-server/prod: true.
+AUTH_COOKIE_SECURE=false
 PASSWORD_RESET_TTL_MINUTES=30
 # dev-only reset link: відображати токен скидання у відповіді API, якщо доставку електронної пошти не налаштовано
 PASSWORD_RESET_EXPOSE_TOKEN=true

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@
 | ---------------- | ------------------------------------------------------- |
 | **Presentation** | React-компоненти, сторінки, форми                       |
 | **State**        | Zustand stores: auth, notifications                     |
-| **API Client**   | Axios-інстанс з JWT interceptors (auto-refresh)         |
+| **API Client**   | Axios-інстанс з cookie-based session interceptors       |
 | **Controller**   | NestJS controllers — прийом HTTP-запитів, валідація DTO |
 | **Service**      | Бізнес-логіка, оркестрація модулів                      |
 | **Data**         | Репозиторії / mock-дані / Mongoose ODM                  |
@@ -153,23 +153,25 @@
 
 **Файли:** `src/auth/`
 
-**Відповідальність:** аутентифікація, видача та оновлення JWT-токенів, перевірка статусу акаунту, зміна та відновлення пароля.
+**Відповідальність:** аутентифікація, видача та оновлення JWT-сесій через захищені cookies, перевірка статусу акаунту, зміна та відновлення пароля.
 
 **Компоненти:**
 
 | Файл                 | Опис                                                                                 |
 | -------------------- | ------------------------------------------------------------------------------------ |
-| `auth.controller.ts` | HTTP-ендпоінти: POST /login, POST /refresh, GET /profile, password reset             |
+| `auth.controller.ts` | HTTP-ендпоінти: POST /login, POST /refresh, GET /profile, password reset, встановлення/очищення auth cookies |
 | `auth.service.ts`    | Валідація пароля (bcrypt), генерація access/refresh токенів, одноразові reset tokens |
-| `jwt.strategy.ts`    | Passport JWT стратегія — декодує токен, додає user до request                        |
+| `jwt.strategy.ts`    | Passport JWT стратегія — читає access token з HttpOnly cookie або Bearer fallback, додає user до request |
 | `jwt-auth.guard.ts`  | Guard — перевіряє наявність та валідність access token                               |
 | `roles.guard.ts`     | Guard — перевіряє ролі за декоратором `@Roles()` з урахуванням ієрархії              |
 
 **Логіка токенів:**
 
-- `accessToken` — дія 15 хв (налаштовується через env)
-- `refreshToken` — дія 7 днів
+- `accessToken` — дія 15 хв (налаштовується через env), видається в `HttpOnly` cookie
+- `refreshToken` — дія 7 днів, видається в окремій `HttpOnly` cookie з вужчим path `/api/auth`
 - Payload: `{ sub: userId, login, role }`
+- Browser clients не отримують токени в JSON і не зберігають їх у `localStorage`
+- Для unsafe HTTP-методів frontend додає signed CSRF token з cookie `campus_csrf_token` у header `X-CSRF-Token`
 - При невірних даних — відповідь без деталей
 - Заблокований акаунт — відмова до перевірки пароля
 - Password reset token генерується криптографічно безпечно, зберігається тільки як SHA-256 hash, має TTL і стає недійсним після використання
@@ -431,10 +433,10 @@ src/
 ├── index.css                ← Tailwind base styles
 ├── types/index.ts           ← всі TS-інтерфейси
 ├── services/
-│   ├── api.ts               ← Axios instance, JWT interceptors, auto-refresh
+│   ├── api.ts               ← Axios instance, cookie session refresh/retry
 │   └── surveysApi.ts        ← typed client для SurveysModule
 ├── store/
-│   ├── authStore.ts         ← Zustand: user, token, login/logout
+│   ├── authStore.ts         ← Zustand: user, session state, login/logout
 │   └── notificationsStore.ts
 ├── components/
 │   ├── Layout.tsx           ← sidebar + header + role-based nav
@@ -612,18 +614,19 @@ AuditLogEntry
 
 ## 7. API — повний опис ендпоінтів
 
-Всі ендпоінти доступні за префіксом `/api`. Всі захищені JwtAuthGuard, крім `/api/auth/login`, `/api/auth/refresh` та password reset ендпоінтів.
+Всі ендпоінти доступні за префіксом `/api`. Всі захищені JwtAuthGuard, крім `/api/auth/login`, `/api/auth/refresh`, `/api/auth/logout` та password reset ендпоінтів.
 
 ### Аутентифікація `/api/auth`
 
 | Метод | Шлях                           | Тіло                           | Відповідь                                            | Доступ        |
 | ----- | ------------------------------ | ------------------------------ | ---------------------------------------------------- | ------------- |
-| POST  | `/auth/login`                  | `{ login, password }`          | `{ accessToken, refreshToken, user }`                | Публічний     |
-| POST  | `/auth/refresh`                | `{ refreshToken }`             | `{ accessToken, refreshToken }`                      | Публічний     |
+| POST  | `/auth/login`                  | `{ login, password }`          | `{ user }` + `HttpOnly` auth cookies                 | Публічний     |
+| POST  | `/auth/refresh`                | cookie або legacy `{ refreshToken }` | `{ success: true }` + оновлені cookies        | Публічний     |
 | POST  | `/auth/password-reset/request` | `{ identifier }`               | `{ message }` + dev reset URL тільки поза production | Публічний     |
 | POST  | `/auth/password-reset/confirm` | `{ token, newPassword }`       | `{ message }`                                        | Публічний     |
 | GET   | `/auth/profile`                | —                              | User з профілями                                     | Авторизований |
 | POST  | `/auth/change-password`        | `{ oldPassword, newPassword }` | 200                                                  | Авторизований |
+| POST  | `/auth/logout`                 | cookie або legacy `{ refreshToken }` | `{ message }` + очищення cookies              | Публічний     |
 
 ### Користувачі `/api/users`
 
@@ -748,13 +751,16 @@ Student        (базовий доступ)
 
 - **bcrypt** (cost factor 12) для хешування паролів
 - **Access token** — короткоживучий (15 хв), мінімізує вікно компрометації
-- **Refresh token** — зберігається в `httpOnly cookie` або захищеному localStorage
+- **Refresh token** — зберігається тільки в `HttpOnly` cookie, недоступній для JavaScript
+- **Cookie flags** — `HttpOnly`, `SameSite=Strict` за замовчуванням, `Secure=true` у production/HTTPS
+- **Token rotation** — refresh endpoint перевипускає access/refresh cookies і відкликає використаний refresh token
+- **CSRF** — signed double-submit token для unsafe методів (`POST`, `PUT`, `PATCH`, `DELETE`)
 
 ### HTTP-безпека
 
 - **HTTPS** обов'язково в production
 - **Helmet** — заголовки: `X-Content-Type-Options`, `X-Frame-Options`, `Strict-Transport-Security`, `Content-Security-Policy`
-- **CORS** — дозволений тільки домен фронтенду
+- **CORS** — дозволені тільки домени фронтенду з `CLIENT_URL`, cookies передаються лише з `credentials: true`
 - **Rate limiting** — `/auth/login` максимум 10 спроб за 15 хвилин з одного IP, password reset endpoints максимум 5 спроб за 15 хвилин
 - **Input validation** — `class-validator` + `ValidationPipe` на всіх DTO
 
@@ -764,7 +770,7 @@ Student        (базовий доступ)
 | ----------------------- | -------------------------------------------------------- |
 | SQL Injection           | Parameterized queries через Mongoose ODM                 |
 | XSS                     | `Content-Security-Policy`, React escaping                |
-| CSRF                    | `SameSite=Strict` cookie, CORS обмеження                 |
+| CSRF                    | `SameSite=Strict` cookie, signed `X-CSRF-Token`, CORS обмеження |
 | Brute Force             | Rate limiting на /auth/login та password reset endpoints |
 | Path Traversal          | Валідація file paths, заборона `../`                     |
 | Sensitive Data Exposure | Пароль ніколи не повертається в API-відповідях           |
@@ -1073,6 +1079,15 @@ cd client && npm run dev
 JWT_SECRET=your-super-secret-key-min-32-chars
 JWT_EXPIRES_IN=15m
 JWT_REFRESH_EXPIRES_IN=7d
+AUTH_ACCESS_COOKIE_NAME=campus_access_token
+AUTH_REFRESH_COOKIE_NAME=campus_refresh_token
+AUTH_ACCESS_COOKIE_PATH=/api
+AUTH_REFRESH_COOKIE_PATH=/api/auth
+AUTH_CSRF_COOKIE_NAME=campus_csrf_token
+AUTH_CSRF_COOKIE_PATH=/
+AUTH_CSRF_HEADER_NAME=x-csrf-token
+AUTH_COOKIE_SAMESITE=strict
+AUTH_COOKIE_SECURE=true
 PASSWORD_RESET_TTL_MINUTES=30
 PASSWORD_RESET_EXPOSE_TOKEN=false
 
@@ -1232,6 +1247,12 @@ jobs:
 | `JWT_SECRET` | секрет для JWT |
 | `PORT` | порт backend |
 | `CLIENT_URL` | URL frontend для CORS і reset links |
+| `AUTH_ACCESS_COOKIE_NAME` | назва HttpOnly cookie для access token |
+| `AUTH_REFRESH_COOKIE_NAME` | назва HttpOnly cookie для refresh token |
+| `AUTH_COOKIE_SECURE` | `true` для HTTPS-середовищ, `false` лише для локального HTTP |
+| `AUTH_COOKIE_SAMESITE` | політика cookies: `strict` за замовчуванням, `lax`/`none` лише за потреби |
+| `AUTH_CSRF_COOKIE_NAME` | назва readable cookie з signed CSRF token |
+| `AUTH_CSRF_HEADER_NAME` | header, який frontend надсилає для unsafe методів (`x-csrf-token`) |
 
 ### Правила роботи із залежностями
 

--- a/client/nginx.conf
+++ b/client/nginx.conf
@@ -8,6 +8,8 @@ server {
         proxy_pass http://server:3000/api/;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
 
     location / {

--- a/client/src/components/Layout.tsx
+++ b/client/src/components/Layout.tsx
@@ -63,7 +63,7 @@ export default function Layout() {
   const [sidebarOpen, setSidebarOpen] = useState(false);
 
   useEffect(() => {
-    if (!user && isAuthenticated && localStorage.getItem('accessToken')) {
+    if (!user && isAuthenticated) {
       loadProfile();
     }
   }, [user, isAuthenticated, loadProfile]);
@@ -73,8 +73,11 @@ export default function Layout() {
   );
 
   const handleLogout = () => {
-    logout();
-    navigate('/login');
+    void logout()
+      .catch(() => undefined)
+      .finally(() => {
+        navigate('/login');
+      });
   };
 
   const pageTitle = useMemo(() => {

--- a/client/src/pages/shared/ProfilePage.tsx
+++ b/client/src/pages/shared/ProfilePage.tsx
@@ -83,7 +83,7 @@ export default function ProfilePage() {
   };
 
   useEffect(() => {
-    if (!user && isAuthenticated && localStorage.getItem('accessToken')) {
+    if (!user && isAuthenticated) {
       loadProfile();
     }
   }, [user, isAuthenticated, loadProfile]);

--- a/client/src/services/api.ts
+++ b/client/src/services/api.ts
@@ -1,28 +1,72 @@
-import axios, { AxiosError, type InternalAxiosRequestConfig } from 'axios';
+import axios, {
+  AxiosError,
+  AxiosHeaders,
+  type InternalAxiosRequestConfig,
+} from 'axios';
 
 const api = axios.create({
   baseURL: '/api',
+  withCredentials: true,
 });
-
-type TokenResponse = {
-  accessToken: string;
-  refreshToken: string;
-};
 
 type RetriableRequestConfig = InternalAxiosRequestConfig & {
   _retry?: boolean;
 };
 
-const TOKEN_REFRESH_MARGIN_MS = 30_000;
 const AUTH_ENDPOINTS = [
   '/auth/login',
   '/auth/refresh',
+  '/auth/logout',
   '/auth/password-reset/request',
   '/auth/password-reset/confirm',
 ];
 const AUTH_PAGES = ['/login', '/forgot-password', '/reset-password'];
+const LEGACY_TOKEN_KEYS = ['accessToken', 'refreshToken'];
+const CSRF_COOKIE_NAME = 'campus_csrf_token';
+const CSRF_HEADER_NAME = 'X-CSRF-Token';
+const MUTATING_METHODS = new Set(['delete', 'patch', 'post', 'put']);
 
-let refreshPromise: Promise<TokenResponse> | null = null;
+let refreshPromise: Promise<void> | null = null;
+
+function clearLegacyAuthStorage() {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  for (const key of LEGACY_TOKEN_KEYS) {
+    localStorage.removeItem(key);
+  }
+}
+
+clearLegacyAuthStorage();
+
+function readCookie(name: string) {
+  if (typeof document === 'undefined') {
+    return null;
+  }
+
+  const cookies = document.cookie.split(';');
+  for (const cookie of cookies) {
+    const separatorIndex = cookie.indexOf('=');
+    if (separatorIndex < 0) {
+      continue;
+    }
+
+    const cookieName = cookie.slice(0, separatorIndex).trim();
+    if (cookieName !== name) {
+      continue;
+    }
+
+    const value = cookie.slice(separatorIndex + 1).trim();
+    try {
+      return decodeURIComponent(value);
+    } catch {
+      return value;
+    }
+  }
+
+  return null;
+}
 
 function getRequestPath(url?: string) {
   if (!url) {
@@ -30,7 +74,10 @@ function getRequestPath(url?: string) {
   }
 
   try {
-    return new URL(url, window.location.origin).pathname.replace(/^\/api/, '');
+    const origin =
+      typeof window === 'undefined' ? 'http://localhost' : window.location.origin;
+
+    return new URL(url, origin).pathname.replace(/^\/api/, '');
   } catch {
     return url.split('?')[0].replace(/^\/api/, '');
   }
@@ -41,71 +88,23 @@ function isAuthEndpoint(url?: string) {
   return AUTH_ENDPOINTS.some((endpoint) => path === endpoint);
 }
 
-function getJwtExpiresAt(token: string) {
-  const [, payload] = token.split('.');
+function clearSessionAndRedirect() {
+  clearLegacyAuthStorage();
 
-  if (!payload) {
-    return null;
+  if (typeof window === 'undefined') {
+    return;
   }
-
-  try {
-    const normalizedPayload = payload.replace(/-/g, '+').replace(/_/g, '/');
-    const paddedPayload = normalizedPayload.padEnd(
-      Math.ceil(normalizedPayload.length / 4) * 4,
-      '=',
-    );
-    const decodedPayload = JSON.parse(window.atob(paddedPayload)) as {
-      exp?: unknown;
-    };
-
-    return typeof decodedPayload.exp === 'number'
-      ? decodedPayload.exp * 1000
-      : null;
-  } catch {
-    return null;
-  }
-}
-
-function isTokenExpiring(token: string) {
-  const expiresAt = getJwtExpiresAt(token);
-  return expiresAt !== null && expiresAt - Date.now() <= TOKEN_REFRESH_MARGIN_MS;
-}
-
-function persistTokens(tokens: TokenResponse) {
-  localStorage.setItem('accessToken', tokens.accessToken);
-  localStorage.setItem('refreshToken', tokens.refreshToken);
-}
-
-function clearTokensAndRedirect() {
-  localStorage.removeItem('accessToken');
-  localStorage.removeItem('refreshToken');
 
   if (!AUTH_PAGES.some((page) => window.location.pathname.startsWith(page))) {
     window.location.href = '/login';
   }
 }
 
-function setAuthorizationHeader(
-  config: InternalAxiosRequestConfig,
-  token: string,
-) {
-  config.headers.Authorization = `Bearer ${token}`;
-}
-
-async function refreshTokens() {
-  const refreshToken = localStorage.getItem('refreshToken');
-
-  if (!refreshToken) {
-    throw new Error('Refresh token is missing');
-  }
-
+async function refreshSession() {
   if (!refreshPromise) {
-    refreshPromise = axios
-      .post<TokenResponse>('/api/auth/refresh', { refreshToken })
-      .then(({ data }) => {
-        persistTokens(data);
-        return data;
-      })
+    refreshPromise = api
+      .post('/auth/refresh', {})
+      .then(() => undefined)
       .finally(() => {
         refreshPromise = null;
       });
@@ -114,20 +113,15 @@ async function refreshTokens() {
   return refreshPromise;
 }
 
-api.interceptors.request.use(async (config) => {
-  let token = localStorage.getItem('accessToken');
+api.interceptors.request.use((config) => {
+  config.withCredentials = true;
 
-  if (token && !isAuthEndpoint(config.url) && isTokenExpiring(token)) {
-    try {
-      token = (await refreshTokens()).accessToken;
-    } catch (error) {
-      clearTokensAndRedirect();
-      return Promise.reject(error);
+  if (MUTATING_METHODS.has(config.method?.toLowerCase() ?? '')) {
+    const csrfToken = readCookie(CSRF_COOKIE_NAME);
+    if (csrfToken) {
+      config.headers = AxiosHeaders.from(config.headers);
+      config.headers.set(CSRF_HEADER_NAME, csrfToken);
     }
-  }
-
-  if (token) {
-    setAuthorizationHeader(config, token);
   }
 
   return config;
@@ -147,11 +141,10 @@ api.interceptors.response.use(
       originalRequest._retry = true;
 
       try {
-        const { accessToken } = await refreshTokens();
-        setAuthorizationHeader(originalRequest, accessToken);
+        await refreshSession();
         return api(originalRequest);
       } catch {
-        clearTokensAndRedirect();
+        clearSessionAndRedirect();
       }
     }
 
@@ -181,12 +174,15 @@ export const filesApi = {
       headers: { 'Content-Type': 'multipart/form-data' },
     });
     const fileId = uploadRes.data.fileId;
-    const submitRes = await api.post(`/courses/assignments/${assignmentId}/submit`, {
-      fileIds: [fileId],
-    });
+    const submitRes = await api.post(
+      `/courses/assignments/${assignmentId}/submit`,
+      {
+        fileIds: [fileId],
+      },
+    );
     return submitRes.data;
   },
-  
+
   deleteFile: async (fileId: string) => {
     return api.delete(`/files/${fileId}`);
   },

--- a/client/src/store/authStore.ts
+++ b/client/src/store/authStore.ts
@@ -10,15 +10,24 @@ interface AuthState {
   isAuthChecked: boolean;
   error: string | null;
   login: (login: string, password: string) => Promise<void>;
-  logout: () => void;
+  logout: () => Promise<void>;
   loadProfile: () => Promise<void>;
   initializeAuth: () => Promise<void>;
   changePassword: (oldPassword: string, newPassword: string) => Promise<string>;
 }
 
+function clearLegacyAuthStorage() {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  localStorage.removeItem('accessToken');
+  localStorage.removeItem('refreshToken');
+}
+
 export const useAuthStore = create<AuthState>((set) => ({
   user: null,
-  isAuthenticated: !!localStorage.getItem('accessToken'),
+  isAuthenticated: false,
   isLoading: false,
   isAuthChecked: false,
   error: null,
@@ -29,9 +38,13 @@ export const useAuthStore = create<AuthState>((set) => ({
     try {
       const { data } = await api.post('/auth/login', { login, password });
 
-      localStorage.setItem('accessToken', data.accessToken);
-      localStorage.setItem('refreshToken', data.refreshToken);
-      set({ user: data.user, isAuthenticated: true, isLoading: false });
+      clearLegacyAuthStorage();
+      set({
+        user: data.user,
+        isAuthenticated: true,
+        isLoading: false,
+        isAuthChecked: true,
+      });
     } catch (err: unknown) {
       const status = axios.isAxiosError(err) ? err.response?.status : undefined;
 
@@ -52,16 +65,19 @@ export const useAuthStore = create<AuthState>((set) => ({
     }
   },
 
-  logout: () => {
-    localStorage.removeItem('accessToken');
-    localStorage.removeItem('refreshToken');
+  logout: async () => {
+    try {
+      await api.post('/auth/logout', {});
+    } finally {
+      clearLegacyAuthStorage();
 
-    set({
-      user: null,
-      isAuthenticated: false,
-      isAuthChecked: true,
-      error: null,
-    });
+      set({
+        user: null,
+        isAuthenticated: false,
+        isAuthChecked: true,
+        error: null,
+      });
+    }
   },
 
   loadProfile: async () => {
@@ -70,6 +86,7 @@ export const useAuthStore = create<AuthState>((set) => ({
     set({
       user: data,
       isAuthenticated: true,
+      isAuthChecked: true,
     });
   },
 
@@ -99,17 +116,6 @@ export const useAuthStore = create<AuthState>((set) => ({
   },
 
   initializeAuth: async () => {
-    const token = localStorage.getItem('accessToken');
-
-    if (!token) {
-      set({
-        user: null,
-        isAuthenticated: false,
-        isAuthChecked: true,
-      });
-      return;
-    }
-
     try {
       const { data } = await api.get('/auth/profile');
 
@@ -120,8 +126,7 @@ export const useAuthStore = create<AuthState>((set) => ({
       });
     } catch (err: unknown) {
       if (axios.isAxiosError(err) && err.response?.status === 401) {
-        localStorage.removeItem('accessToken');
-        localStorage.removeItem('refreshToken');
+        clearLegacyAuthStorage();
 
         set({
           user: null,
@@ -134,7 +139,7 @@ export const useAuthStore = create<AuthState>((set) => ({
 
       set({
         user: null,
-        isAuthenticated: true,
+        isAuthenticated: false,
         isAuthChecked: true,
       });
     }

--- a/scripts/pre-commit.mjs
+++ b/scripts/pre-commit.mjs
@@ -47,7 +47,7 @@ function runNpm(args) {
     return;
   }
 
-  run(process.platform === 'win32' ? 'npm.cmd' : 'npm', args);
+  run('npm', args, { shell: true });
 }
 
 function isCodeFile(filePath) {

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -7,6 +7,7 @@ import { AuditLogModule } from './audit-log/audit-log.module';
 import { AuditInterceptor } from './audit-log/audit.interceptor';
 import { RequestIdMiddleware } from './common/middleware/request-id.middleware';
 import { UserAwareThrottlerGuard } from './common/guards/user-aware-throttler.guard';
+import { CsrfGuard } from './common/guards/csrf.guard';
 import { ExistsInDatabaseConstraint } from './common/validators/exists-in-database.validator';
 import { SeedModule } from './seed/seed.module';
 import { AuthModule } from './auth/auth.module';
@@ -77,6 +78,7 @@ function readPositiveNumber(
     SurveysModule,
   ],
   providers: [
+    { provide: APP_GUARD, useClass: CsrfGuard },
     { provide: APP_GUARD, useClass: UserAwareThrottlerGuard },
     { provide: APP_INTERCEPTOR, useClass: AuditInterceptor },
     ExistsInDatabaseConstraint,

--- a/server/src/auth/auth-cookie.util.spec.ts
+++ b/server/src/auth/auth-cookie.util.spec.ts
@@ -1,0 +1,27 @@
+import { Request } from 'express';
+import {
+  createSignedCsrfToken,
+  readCookie,
+  verifySignedCsrfToken,
+} from './auth-cookie.util';
+
+describe('auth-cookie utilities', () => {
+  it('reads encoded cookies by name', () => {
+    const req = {
+      headers: {
+        cookie: 'first=value; session=hello%20world; empty=',
+      },
+    } as Request;
+
+    expect(readCookie(req, 'session')).toBe('hello world');
+    expect(readCookie(req, 'missing')).toBeNull();
+  });
+
+  it('creates and verifies signed CSRF tokens', () => {
+    const token = createSignedCsrfToken('secret');
+
+    expect(verifySignedCsrfToken(token, 'secret')).toBe(true);
+    expect(verifySignedCsrfToken(token, 'other-secret')).toBe(false);
+    expect(verifySignedCsrfToken('malformed-token', 'secret')).toBe(false);
+  });
+});

--- a/server/src/auth/auth-cookie.util.ts
+++ b/server/src/auth/auth-cookie.util.ts
@@ -1,0 +1,62 @@
+import { Request } from 'express';
+import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
+
+export const DEFAULT_ACCESS_TOKEN_COOKIE_NAME = 'campus_access_token';
+export const DEFAULT_REFRESH_TOKEN_COOKIE_NAME = 'campus_refresh_token';
+export const DEFAULT_CSRF_TOKEN_COOKIE_NAME = 'campus_csrf_token';
+export const DEFAULT_CSRF_TOKEN_HEADER_NAME = 'x-csrf-token';
+
+export function readCookie(req: Request, name: string): string | null {
+  const cookieHeader = req.headers.cookie;
+  if (!cookieHeader) {
+    return null;
+  }
+
+  const cookies = cookieHeader.split(';');
+  for (const cookie of cookies) {
+    const separatorIndex = cookie.indexOf('=');
+    if (separatorIndex < 0) {
+      continue;
+    }
+
+    const cookieName = cookie.slice(0, separatorIndex).trim();
+    if (cookieName !== name) {
+      continue;
+    }
+
+    const value = cookie.slice(separatorIndex + 1).trim();
+    try {
+      return decodeURIComponent(value);
+    } catch {
+      return value;
+    }
+  }
+
+  return null;
+}
+
+export function createSignedCsrfToken(secret: string): string {
+  const nonce = randomBytes(32).toString('base64url');
+  const signature = signCsrfNonce(nonce, secret);
+
+  return `${nonce}.${signature}`;
+}
+
+export function verifySignedCsrfToken(token: string, secret: string): boolean {
+  const [nonce, signature] = token.split('.');
+  if (!nonce || !signature) {
+    return false;
+  }
+
+  const expectedSignature = signCsrfNonce(nonce, secret);
+  const provided = Buffer.from(signature);
+  const expected = Buffer.from(expectedSignature);
+
+  return (
+    provided.length === expected.length && timingSafeEqual(provided, expected)
+  );
+}
+
+function signCsrfNonce(nonce: string, secret: string): string {
+  return createHmac('sha256', secret).update(nonce).digest('base64url');
+}

--- a/server/src/auth/auth.controller.ts
+++ b/server/src/auth/auth.controller.ts
@@ -5,9 +5,12 @@ import {
   Get,
   UseGuards,
   Req,
+  Res,
   HttpCode,
+  UnauthorizedException,
 } from '@nestjs/common';
 import { Throttle } from '@nestjs/throttler';
+import { ConfigService } from '@nestjs/config';
 import { AuthService } from './auth.service';
 import { JwtAuthGuard } from './jwt-auth.guard';
 import {
@@ -25,15 +28,123 @@ import { RequestPasswordResetDto } from './dto/request-password-reset.dto';
 import { ConfirmPasswordResetDto } from './dto/confirm-password-reset.dto';
 import { AuthResponseDto } from './dto/auth-response.dto';
 import { RequestWithId } from '../common/middleware/request-id.middleware';
+import { Response, CookieOptions } from 'express';
+import {
+  createSignedCsrfToken,
+  DEFAULT_ACCESS_TOKEN_COOKIE_NAME,
+  DEFAULT_CSRF_TOKEN_COOKIE_NAME,
+  DEFAULT_REFRESH_TOKEN_COOKIE_NAME,
+  readCookie,
+} from './auth-cookie.util';
 
 interface RequestWithUser extends RequestWithId {
   user: { sub: string; login: string; role?: string };
 }
 
+type AuthTokens = {
+  accessToken: string;
+  refreshToken: string;
+  user?: unknown;
+};
+
+const DEFAULT_ACCESS_TOKEN_MAX_AGE_MS = 15 * 60 * 1000;
+const DEFAULT_REFRESH_TOKEN_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+const DURATION_UNITS_IN_MS: Record<string, number> = {
+  ms: 1,
+  s: 1000,
+  m: 60 * 1000,
+  h: 60 * 60 * 1000,
+  d: 24 * 60 * 60 * 1000,
+};
+
+function durationToMs(value: string | undefined, fallback: number) {
+  if (!value) {
+    return fallback;
+  }
+
+  const trimmed = value.trim();
+  if (/^\d+$/.test(trimmed)) {
+    return Number(trimmed) * 1000;
+  }
+
+  const match = /^(\d+)\s*(ms|s|m|h|d)$/i.exec(trimmed);
+  if (!match) {
+    return fallback;
+  }
+
+  return Number(match[1]) * DURATION_UNITS_IN_MS[match[2].toLowerCase()];
+}
+
+function readBooleanFlag(value: string | undefined, fallback: boolean) {
+  if (value === undefined) {
+    return fallback;
+  }
+
+  return ['1', 'true', 'yes'].includes(value.toLowerCase());
+}
+
+function readSameSite(value: string | undefined): CookieOptions['sameSite'] {
+  const normalized = value?.toLowerCase();
+  if (normalized === 'lax' || normalized === 'none') {
+    return normalized;
+  }
+
+  return 'strict';
+}
+
 @ApiTags('auth')
 @Controller('auth')
 export class AuthController {
-  constructor(private readonly authService: AuthService) {}
+  private readonly accessCookieName: string;
+  private readonly refreshCookieName: string;
+  private readonly csrfCookieName: string;
+  private readonly accessCookiePath: string;
+  private readonly refreshCookiePath: string;
+  private readonly csrfCookiePath: string;
+  private readonly cookieSecure: boolean;
+  private readonly cookieSameSite: CookieOptions['sameSite'];
+  private readonly accessTokenMaxAgeMs: number;
+  private readonly refreshTokenMaxAgeMs: number;
+  private readonly csrfSecret: string;
+
+  constructor(
+    private readonly authService: AuthService,
+    configService: ConfigService,
+  ) {
+    this.accessCookieName =
+      configService.get<string>('AUTH_ACCESS_COOKIE_NAME') ??
+      DEFAULT_ACCESS_TOKEN_COOKIE_NAME;
+    this.refreshCookieName =
+      configService.get<string>('AUTH_REFRESH_COOKIE_NAME') ??
+      DEFAULT_REFRESH_TOKEN_COOKIE_NAME;
+    this.csrfCookieName =
+      configService.get<string>('AUTH_CSRF_COOKIE_NAME') ??
+      DEFAULT_CSRF_TOKEN_COOKIE_NAME;
+    this.accessCookiePath =
+      configService.get<string>('AUTH_ACCESS_COOKIE_PATH') ?? '/api';
+    this.refreshCookiePath =
+      configService.get<string>('AUTH_REFRESH_COOKIE_PATH') ?? '/api/auth';
+    this.csrfCookiePath =
+      configService.get<string>('AUTH_CSRF_COOKIE_PATH') ?? '/';
+    this.cookieSameSite = readSameSite(
+      configService.get<string>('AUTH_COOKIE_SAMESITE'),
+    );
+    this.cookieSecure =
+      this.cookieSameSite === 'none' ||
+      readBooleanFlag(
+        configService.get<string>('AUTH_COOKIE_SECURE'),
+        configService.get<string>('NODE_ENV') === 'production',
+      );
+    this.accessTokenMaxAgeMs = durationToMs(
+      configService.get<string>('JWT_EXPIRES_IN'),
+      DEFAULT_ACCESS_TOKEN_MAX_AGE_MS,
+    );
+    this.refreshTokenMaxAgeMs = durationToMs(
+      configService.get<string>('JWT_REFRESH_EXPIRES_IN'),
+      DEFAULT_REFRESH_TOKEN_MAX_AGE_MS,
+    );
+    this.csrfSecret = configService.getOrThrow<string>('JWT_SECRET');
+  }
 
   @Throttle({ default: { limit: 10, ttl: 900000 } })
   @Post('login')
@@ -43,16 +154,22 @@ export class AuthController {
   @ApiResponse({ status: 401, description: 'Невірний логін або пароль' })
   @ApiResponse({ status: 403, description: 'Обліковий запис заблоковано' })
   @ApiResponse({ status: 429, description: 'Too Many Requests' })
-  async login(@Body() body: LoginDto, @Req() req: RequestWithId) {
+  async login(
+    @Body() body: LoginDto,
+    @Req() req: RequestWithId,
+    @Res({ passthrough: true }) res: Response,
+  ) {
     const ip = req.ip || req.socket?.remoteAddress || 'unknown';
     const userAgent = req.get('user-agent') || 'unknown';
-    return this.authService.login(
+    const auth = await this.authService.login(
       body.login,
       body.password,
       ip,
       userAgent,
       req.requestId,
     );
+    this.setAuthCookies(res, auth);
+    return { user: auth.user };
   }
 
   @Throttle({ default: { limit: 5, ttl: 900000 } })
@@ -105,17 +222,35 @@ export class AuthController {
   @Post('refresh')
   @ApiOperation({ summary: 'Refresh JWT token' })
   @ApiBody({ type: RefreshDto })
-  @ApiResponse({ status: 200, description: 'New access/refresh tokens issued' })
+  @ApiResponse({ status: 200, description: 'Session cookies refreshed' })
   @ApiResponse({ status: 401, description: 'Невірний refresh token' })
-  refresh(@Body() body: RefreshDto, @Req() req: RequestWithId) {
+  async refresh(
+    @Body() body: RefreshDto,
+    @Req() req: RequestWithId,
+    @Res({ passthrough: true }) res: Response,
+  ) {
     const ip = req.ip || req.socket?.remoteAddress || 'unknown';
     const userAgent = req.get('user-agent') || 'unknown';
-    return this.authService.refresh(
-      body.refreshToken,
-      ip,
-      userAgent,
-      req.requestId,
-    );
+    const refreshToken = this.getRefreshToken(req, body.refreshToken);
+
+    if (!refreshToken) {
+      this.clearAuthCookies(res);
+      throw new UnauthorizedException('Невірний refresh token');
+    }
+
+    try {
+      const auth = await this.authService.refresh(
+        refreshToken,
+        ip,
+        userAgent,
+        req.requestId,
+      );
+      this.setAuthCookies(res, auth);
+      return { success: true };
+    } catch (error) {
+      this.clearAuthCookies(res);
+      throw error;
+    }
   }
 
   @Throttle({ default: { limit: 30, ttl: 60000 } })
@@ -124,15 +259,21 @@ export class AuthController {
   @ApiBody({ type: LogoutDto })
   @ApiResponse({ status: 200, description: 'Logged out' })
   @ApiResponse({ status: 401, description: 'Невірний refresh token' })
-  logout(@Body() body: LogoutDto, @Req() req: RequestWithId) {
+  logout(
+    @Body() body: LogoutDto,
+    @Req() req: RequestWithId,
+    @Res({ passthrough: true }) res: Response,
+  ) {
     const ip = req.ip || req.socket?.remoteAddress || 'unknown';
     const userAgent = req.get('user-agent') || 'unknown';
-    return this.authService.logout(
-      body.refreshToken,
-      ip,
-      userAgent,
-      req.requestId,
-    );
+    const refreshToken = this.getRefreshToken(req, body.refreshToken);
+    this.clearAuthCookies(res);
+
+    if (!refreshToken) {
+      return { message: 'Logged out' };
+    }
+
+    return this.authService.logout(refreshToken, ip, userAgent, req.requestId);
   }
 
   @ApiBearerAuth()
@@ -166,5 +307,66 @@ export class AuthController {
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   async getProfile(@Req() req: RequestWithUser) {
     return this.authService.getProfile(req.user.sub);
+  }
+
+  private setAuthCookies(res: Response, auth: AuthTokens) {
+    res.cookie(
+      this.accessCookieName,
+      auth.accessToken,
+      this.buildCookieOptions(this.accessCookiePath, this.accessTokenMaxAgeMs),
+    );
+    res.cookie(
+      this.refreshCookieName,
+      auth.refreshToken,
+      this.buildCookieOptions(
+        this.refreshCookiePath,
+        this.refreshTokenMaxAgeMs,
+      ),
+    );
+    res.cookie(
+      this.csrfCookieName,
+      createSignedCsrfToken(this.csrfSecret),
+      this.buildCookieOptions(
+        this.csrfCookiePath,
+        this.refreshTokenMaxAgeMs,
+        false,
+      ),
+    );
+  }
+
+  private clearAuthCookies(res: Response) {
+    res.clearCookie(
+      this.accessCookieName,
+      this.buildCookieOptions(this.accessCookiePath),
+    );
+    res.clearCookie(
+      this.refreshCookieName,
+      this.buildCookieOptions(this.refreshCookiePath),
+    );
+    res.clearCookie(
+      this.csrfCookieName,
+      this.buildCookieOptions(this.csrfCookiePath, undefined, false),
+    );
+  }
+
+  private buildCookieOptions(
+    path: string,
+    maxAge?: number,
+    httpOnly = true,
+  ): CookieOptions {
+    return {
+      httpOnly,
+      secure: this.cookieSecure,
+      sameSite: this.cookieSameSite,
+      path,
+      ...(maxAge ? { maxAge } : {}),
+    };
+  }
+
+  private getRefreshToken(req: RequestWithId, fallback?: string) {
+    return (
+      readCookie(req, this.refreshCookieName) ??
+      (typeof fallback === 'string' && fallback.trim() ? fallback.trim() : null)
+    );
   }
 }

--- a/server/src/auth/dto/auth-response.dto.ts
+++ b/server/src/auth/dto/auth-response.dto.ts
@@ -21,12 +21,6 @@ export class UserProfileDto {
 }
 
 export class AuthResponseDto {
-  @ApiProperty({ example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...' })
-  accessToken: string;
-
-  @ApiProperty({ example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...' })
-  refreshToken: string;
-
   @ApiProperty({ type: UserProfileDto })
   user?: UserProfileDto;
 }

--- a/server/src/auth/dto/logout.dto.ts
+++ b/server/src/auth/dto/logout.dto.ts
@@ -1,9 +1,12 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsString } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsString } from 'class-validator';
 
 export class LogoutDto {
-  @ApiProperty({ description: 'The refresh token' })
+  @ApiPropertyOptional({
+    description:
+      'Legacy refresh token fallback. Browser clients use the HttpOnly cookie.',
+  })
+  @IsOptional()
   @IsString()
-  @IsNotEmpty()
-  refreshToken: string;
+  refreshToken?: string;
 }

--- a/server/src/auth/dto/refresh.dto.ts
+++ b/server/src/auth/dto/refresh.dto.ts
@@ -1,9 +1,12 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsString } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsString } from 'class-validator';
 
 export class RefreshDto {
-  @ApiProperty({ description: 'The refresh token' })
+  @ApiPropertyOptional({
+    description:
+      'Legacy refresh token fallback. Browser clients use the HttpOnly cookie.',
+  })
+  @IsOptional()
   @IsString()
-  @IsNotEmpty()
-  refreshToken: string;
+  refreshToken?: string;
 }

--- a/server/src/auth/jwt.strategy.ts
+++ b/server/src/auth/jwt.strategy.ts
@@ -6,7 +6,12 @@ import {
 import { PassportStrategy } from '@nestjs/passport';
 import { ConfigService } from '@nestjs/config';
 import { ExtractJwt, Strategy } from 'passport-jwt';
+import { Request } from 'express';
 import { UsersService } from '../users/users.service';
+import {
+  DEFAULT_ACCESS_TOKEN_COOKIE_NAME,
+  readCookie,
+} from './auth-cookie.util';
 
 interface JwtPayload {
   sub: string;
@@ -39,8 +44,15 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
       throw new Error('JWT_SECRET is not set');
     }
 
+    const accessCookieName =
+      config.get<string>('AUTH_ACCESS_COOKIE_NAME') ??
+      DEFAULT_ACCESS_TOKEN_COOKIE_NAME;
+
     super({
-      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      jwtFromRequest: ExtractJwt.fromExtractors([
+        (req: Request) => readCookie(req, accessCookieName),
+        ExtractJwt.fromAuthHeaderAsBearerToken(),
+      ]),
       ignoreExpiration: false,
       secretOrKey: secret,
     });

--- a/server/src/common/guards/csrf.guard.spec.ts
+++ b/server/src/common/guards/csrf.guard.spec.ts
@@ -1,0 +1,82 @@
+import { ExecutionContext, ForbiddenException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Request } from 'express';
+import { createSignedCsrfToken } from '../../auth/auth-cookie.util';
+import { CsrfGuard } from './csrf.guard';
+
+const JWT_SECRET = 'test-secret';
+
+function createGuard() {
+  return new CsrfGuard(new ConfigService({ JWT_SECRET }));
+}
+
+function createContext(req: Partial<Request>) {
+  return {
+    switchToHttp: () => ({
+      getRequest: () => req,
+    }),
+  } as ExecutionContext;
+}
+
+describe('CsrfGuard', () => {
+  it('allows safe requests', () => {
+    const guard = createGuard();
+    const context = createContext({ method: 'GET', path: '/api/users' });
+
+    expect(guard.canActivate(context)).toBe(true);
+  });
+
+  it('allows public unsafe requests without auth cookies', () => {
+    const guard = createGuard();
+    const context = createContext({
+      method: 'POST',
+      path: '/api/auth/login',
+      headers: {},
+    });
+
+    expect(guard.canActivate(context)).toBe(true);
+  });
+
+  it('allows unsafe cookie-session requests with a valid CSRF token', () => {
+    const guard = createGuard();
+    const csrfToken = createSignedCsrfToken(JWT_SECRET);
+    const context = createContext({
+      method: 'PATCH',
+      path: '/api/users/1',
+      headers: {
+        cookie: `campus_access_token=access; campus_csrf_token=${csrfToken}`,
+        'x-csrf-token': csrfToken,
+      },
+    });
+
+    expect(guard.canActivate(context)).toBe(true);
+  });
+
+  it('rejects unsafe cookie-session requests without a matching CSRF header', () => {
+    const guard = createGuard();
+    const csrfToken = createSignedCsrfToken(JWT_SECRET);
+    const context = createContext({
+      method: 'POST',
+      path: '/api/users',
+      headers: {
+        cookie: `campus_access_token=access; campus_csrf_token=${csrfToken}`,
+      },
+    });
+
+    expect(() => guard.canActivate(context)).toThrow(ForbiddenException);
+  });
+
+  it('keeps refresh and logout available for session recovery', () => {
+    const guard = createGuard();
+
+    for (const path of ['/api/auth/refresh', '/api/auth/logout']) {
+      const context = createContext({
+        method: 'POST',
+        path,
+        headers: { cookie: 'campus_refresh_token=refresh' },
+      });
+
+      expect(guard.canActivate(context)).toBe(true);
+    }
+  });
+});

--- a/server/src/common/guards/csrf.guard.ts
+++ b/server/src/common/guards/csrf.guard.ts
@@ -1,0 +1,96 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Request } from 'express';
+import {
+  DEFAULT_ACCESS_TOKEN_COOKIE_NAME,
+  DEFAULT_CSRF_TOKEN_COOKIE_NAME,
+  DEFAULT_CSRF_TOKEN_HEADER_NAME,
+  DEFAULT_REFRESH_TOKEN_COOKIE_NAME,
+  readCookie,
+  verifySignedCsrfToken,
+} from '../../auth/auth-cookie.util';
+
+const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
+const CSRF_EXEMPT_PATHS = new Set([
+  '/auth/login',
+  '/auth/logout',
+  '/auth/refresh',
+  '/auth/password-reset/request',
+  '/auth/password-reset/confirm',
+]);
+
+@Injectable()
+export class CsrfGuard implements CanActivate {
+  private readonly accessCookieName: string;
+  private readonly refreshCookieName: string;
+  private readonly csrfCookieName: string;
+  private readonly csrfHeaderName: string;
+  private readonly csrfSecret: string;
+
+  constructor(configService: ConfigService) {
+    this.accessCookieName =
+      configService.get<string>('AUTH_ACCESS_COOKIE_NAME') ??
+      DEFAULT_ACCESS_TOKEN_COOKIE_NAME;
+    this.refreshCookieName =
+      configService.get<string>('AUTH_REFRESH_COOKIE_NAME') ??
+      DEFAULT_REFRESH_TOKEN_COOKIE_NAME;
+    this.csrfCookieName =
+      configService.get<string>('AUTH_CSRF_COOKIE_NAME') ??
+      DEFAULT_CSRF_TOKEN_COOKIE_NAME;
+    this.csrfHeaderName = (
+      configService.get<string>('AUTH_CSRF_HEADER_NAME') ??
+      DEFAULT_CSRF_TOKEN_HEADER_NAME
+    ).toLowerCase();
+    this.csrfSecret = configService.getOrThrow<string>('JWT_SECRET');
+  }
+
+  canActivate(context: ExecutionContext): boolean {
+    const req = context.switchToHttp().getRequest<Request>();
+    if (SAFE_METHODS.has(req.method.toUpperCase())) {
+      return true;
+    }
+
+    if (CSRF_EXEMPT_PATHS.has(req.path.replace(/^\/api/, ''))) {
+      return true;
+    }
+
+    if (!this.hasCookieSession(req)) {
+      return true;
+    }
+
+    const cookieToken = readCookie(req, this.csrfCookieName);
+    const headerToken = this.getHeaderToken(req);
+
+    if (
+      !cookieToken ||
+      !headerToken ||
+      cookieToken !== headerToken ||
+      !verifySignedCsrfToken(cookieToken, this.csrfSecret)
+    ) {
+      throw new ForbiddenException('Invalid CSRF token');
+    }
+
+    return true;
+  }
+
+  private hasCookieSession(req: Request): boolean {
+    return Boolean(
+      readCookie(req, this.accessCookieName) ||
+      readCookie(req, this.refreshCookieName),
+    );
+  }
+
+  private getHeaderToken(req: Request): string | null {
+    const value = req.headers[this.csrfHeaderName];
+    if (Array.isArray(value)) {
+      return value[0] ?? null;
+    }
+
+    return typeof value === 'string' ? value : null;
+  }
+}

--- a/server/src/common/guards/user-aware-throttler.guard.ts
+++ b/server/src/common/guards/user-aware-throttler.guard.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
+import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
 import {
   InjectThrottlerOptions,
@@ -9,6 +10,10 @@ import {
   ThrottlerStorage,
 } from '@nestjs/throttler';
 import { Request } from 'express';
+import {
+  DEFAULT_ACCESS_TOKEN_COOKIE_NAME,
+  readCookie,
+} from '../../auth/auth-cookie.util';
 
 type RequestUser = {
   sub?: unknown;
@@ -31,6 +36,7 @@ export class UserAwareThrottlerGuard extends ThrottlerGuard {
     storageService: ThrottlerStorage,
     reflector: Reflector,
     private readonly jwtService: JwtService,
+    private readonly configService: ConfigService,
   ) {
     super(options, storageService, reflector);
   }
@@ -65,6 +71,15 @@ export class UserAwareThrottlerGuard extends ThrottlerGuard {
   }
 
   private extractBearerToken(req: Request): string | null {
+    const cookieToken = readCookie(
+      req,
+      this.configService.get<string>('AUTH_ACCESS_COOKIE_NAME') ??
+        DEFAULT_ACCESS_TOKEN_COOKIE_NAME,
+    );
+    if (cookieToken) {
+      return cookieToken;
+    }
+
     const authorization = req.headers.authorization;
     if (!authorization) {
       return null;

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -48,10 +48,31 @@ async function bootstrap() {
     next();
   });
 
+  const allowedOrigins = (process.env.CLIENT_URL || 'http://localhost:5173')
+    .split(',')
+    .map((origin) => origin.trim().replace(/\/+$/, ''))
+    .filter(Boolean);
+
   app.enableCors({
-    origin: process.env.CLIENT_URL || 'http://localhost:5173',
+    origin: (
+      origin: string | undefined,
+      callback: (err: Error | null, allow?: boolean) => void,
+    ) => {
+      if (!origin || allowedOrigins.includes(origin)) {
+        callback(null, true);
+        return;
+      }
+
+      callback(new Error('Not allowed by CORS'));
+    },
     credentials: true,
     methods: 'GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS',
+    allowedHeaders: [
+      'Content-Type',
+      'Authorization',
+      'X-Request-Id',
+      'X-CSRF-Token',
+    ],
   });
 
   // Захист: Сувора валідація


### PR DESCRIPTION
## Summary

- Moved browser authentication from localStorage tokens to HttpOnly cookie-based sessions.
- Added access/refresh cookie configuration with SameSite, Secure, scoped paths and refresh rotation.
- Added signed CSRF protection for unsafe cookie-session requests.
- Updated the SPA API client to use credentials, refresh sessions via cookies and send CSRF headers.
- Kept legacy token cleanup so old localStorage auth data is removed after deploy.
- Hardened CORS and nginx proxy headers for cookie-based auth.
- Updated README and env examples with the new auth/security settings.
- Fixed the pre-commit helper to avoid the deprecated platform check.

## Verification

- server: `npm run lint:check`
- server: `npm run build`
- server: `npm test`
- client: `npm run lint`
- client: `npm run build`
- server/client: `npm audit --audit-level=moderate`
- `git diff --check`