### PR TITLE
fix(files): restrict student access to submission files

### DIFF
--- a/server/src/files/files.service.spec.ts
+++ b/server/src/files/files.service.spec.ts
@@ -110,6 +110,38 @@ describe('FilesService security checks', () => {
     ).resolves.toBe(file);
   });
 
+  it('blocks a student from downloading another student submission file from the same group', async () => {
+    const fileId = new Types.ObjectId();
+    const ownerId = new Types.ObjectId();
+    const requesterId = new Types.ObjectId();
+    const courseAssignmentId = new Types.ObjectId();
+    const groupId = new Types.ObjectId();
+
+    const service = createService({
+      file: { _id: fileId, uploadedBy: ownerId },
+      submissions: [
+        {
+          student: ownerId,
+          assignment: new Types.ObjectId(),
+        },
+      ],
+      submittedAssignment: { courseAssignment: courseAssignmentId },
+      courseAssignment: {
+        teacher: new Types.ObjectId(),
+        group: groupId,
+      },
+      user: { studentProfile: { group: groupId } },
+    });
+
+    await expect(
+      service.getDownloadableFileById(
+        fileId.toHexString(),
+        requesterId.toHexString(),
+        Role.STUDENT,
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
   it('rejects downloads when the file has no allowed relation to the user', async () => {
     const fileId = new Types.ObjectId();
     const ownerId = new Types.ObjectId();

--- a/server/src/files/files.service.ts
+++ b/server/src/files/files.service.ts
@@ -246,6 +246,7 @@ export class FilesService {
         .exec();
 
       if (
+        role !== Role.STUDENT &&
         submittedAssignment &&
         (await this.canAccessCourseAssignment(
           toId(submittedAssignment.courseAssignment),


### PR DESCRIPTION
Prevent students from downloading classmates' submission files through the course-assignment fallback and add a regression test for same-group access.