### PR TITLE
security(deploy): harden auth sessions and compose defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,8 +31,6 @@ MONGO_ROOT_PASSWORD=your_secure_password
 MONGO_DATABASE=campus_db
 MONGO_HOST=mongodb
 MONGO_PORT=27017
-# Docker Compose за замовчуванням прив'язує MongoDB лише до localhost
-MONGO_BIND_IP=127.0.0.1
 MONGO_RETRY_ATTEMPTS=20
 MONGO_RETRY_DELAY_MS=3000
 MONGO_SERVER_SELECTION_TIMEOUT_MS=5000

--- a/README.md
+++ b/README.md
@@ -1095,13 +1095,25 @@ PASSWORD_RESET_TTL_MINUTES=30
 PASSWORD_RESET_EXPOSE_TOKEN=false
 SWAGGER_ENABLED=false
 
-# БД [Phase 2]
-DATABASE_URL=mongodb://mongo:27017/campus
+# MongoDB
+MONGO_ROOT_USERNAME=admin
+MONGO_ROOT_PASSWORD=your-strong-mongo-root-password
+MONGO_DATABASE=campus_db
+MONGO_HOST=mongodb
+MONGO_PORT=27017
+MONGO_RETRY_ATTEMPTS=20
+MONGO_RETRY_DELAY_MS=3000
+MONGO_SERVER_SELECTION_TIMEOUT_MS=5000
 
 # Production
 PORT=3000
 NODE_ENV=production
 ```
+
+У локальному `docker-compose.yml` MongoDB доступна backend-контейнеру через
+внутрішню Docker network (`mongodb:27017`) і не публікується на host-порт за
+замовчуванням. Це прибирає конфлікти з локально встановленою MongoDB або іншими
+проєктами, які вже займають `127.0.0.1:27017`.
 
 ### Production (VPS)
 

--- a/client/nginx.conf
+++ b/client/nginx.conf
@@ -4,6 +4,13 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    add_header Content-Security-Policy "default-src 'self'; connect-src 'self'; img-src 'self' data: blob:; font-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=(), usb=()" always;
+
     location /api/ {
         proxy_pass http://server:3000/api/;
         proxy_set_header Host $host;

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,6 +7,7 @@ import ForgotPasswordPage from './pages/auth/ForgotPasswordPage';
 import { lazy, Suspense, useEffect } from 'react';
 import type { ReactNode } from 'react';
 import { useAuthStore } from './store/authStore';
+import { AUTH_SESSION_EXPIRED_EVENT } from './services/api';
 
 const DashboardPage = lazy(() => import('./pages/shared/DashboardPage'));
 const SchedulePage = lazy(() => import('./pages/shared/SchedulePage'));
@@ -45,10 +46,19 @@ function LazyPage({ children }: { children: ReactNode }) {
 
 export default function App() {
   const initializeAuth = useAuthStore((state) => state.initializeAuth);
+  const expireSession = useAuthStore((state) => state.expireSession);
 
   useEffect(() => {
     initializeAuth();
   }, [initializeAuth]);
+
+  useEffect(() => {
+    window.addEventListener(AUTH_SESSION_EXPIRED_EVENT, expireSession);
+
+    return () => {
+      window.removeEventListener(AUTH_SESSION_EXPIRED_EVENT, expireSession);
+    };
+  }, [expireSession]);
 
   return (
     <BrowserRouter>

--- a/client/src/components/Layout.tsx
+++ b/client/src/components/Layout.tsx
@@ -64,7 +64,7 @@ export default function Layout() {
 
   useEffect(() => {
     if (!user && isAuthenticated) {
-      loadProfile();
+      void loadProfile().catch(() => undefined);
     }
   }, [user, isAuthenticated, loadProfile]);
 

--- a/client/src/services/api.ts
+++ b/client/src/services/api.ts
@@ -5,7 +5,7 @@ import axios, {
 } from 'axios';
 
 const api = axios.create({
-  baseURL: '/api',
+  baseURL: import.meta.env.VITE_API_URL?.trim() || '/api',
   withCredentials: true,
 });
 
@@ -25,8 +25,10 @@ const LEGACY_TOKEN_KEYS = ['accessToken', 'refreshToken'];
 const CSRF_COOKIE_NAME = 'campus_csrf_token';
 const CSRF_HEADER_NAME = 'X-CSRF-Token';
 const MUTATING_METHODS = new Set(['delete', 'patch', 'post', 'put']);
+export const AUTH_SESSION_EXPIRED_EVENT = 'campus:auth-session-expired';
 
 let refreshPromise: Promise<void> | null = null;
+let sessionExpirationHandled = false;
 
 function clearLegacyAuthStorage() {
   if (typeof window === 'undefined') {
@@ -88,15 +90,30 @@ function isAuthEndpoint(url?: string) {
   return AUTH_ENDPOINTS.some((endpoint) => path === endpoint);
 }
 
-function clearSessionAndRedirect() {
+function isAuthPage() {
+  return AUTH_PAGES.some((page) => window.location.pathname.startsWith(page));
+}
+
+function resetSessionExpirationHandling() {
+  sessionExpirationHandled = false;
+}
+
+function expireSession() {
   clearLegacyAuthStorage();
 
   if (typeof window === 'undefined') {
     return;
   }
 
-  if (!AUTH_PAGES.some((page) => window.location.pathname.startsWith(page))) {
-    window.location.href = '/login';
+  if (sessionExpirationHandled) {
+    return;
+  }
+
+  sessionExpirationHandled = true;
+  window.dispatchEvent(new Event(AUTH_SESSION_EXPIRED_EVENT));
+
+  if (!isAuthPage()) {
+    window.location.replace('/login');
   }
 }
 
@@ -128,9 +145,22 @@ api.interceptors.request.use((config) => {
 });
 
 api.interceptors.response.use(
-  (response) => response,
+  (response) => {
+    const path = getRequestPath(response.config.url);
+    if (path === '/auth/login' || path === '/auth/refresh') {
+      resetSessionExpirationHandling();
+    }
+
+    return response;
+  },
   async (error: AxiosError) => {
     const originalRequest = error.config as RetriableRequestConfig | undefined;
+    const requestPath = getRequestPath(originalRequest?.url);
+
+    if (error.response?.status === 401 && requestPath === '/auth/refresh') {
+      expireSession();
+      return Promise.reject(error);
+    }
 
     if (
       error.response?.status === 401 &&
@@ -144,7 +174,7 @@ api.interceptors.response.use(
         await refreshSession();
         return api(originalRequest);
       } catch {
-        clearSessionAndRedirect();
+        expireSession();
       }
     }
 

--- a/client/src/store/authStore.ts
+++ b/client/src/store/authStore.ts
@@ -14,6 +14,7 @@ interface AuthState {
   loadProfile: () => Promise<void>;
   initializeAuth: () => Promise<void>;
   changePassword: (oldPassword: string, newPassword: string) => Promise<string>;
+  expireSession: () => void;
 }
 
 function clearLegacyAuthStorage() {
@@ -31,6 +32,17 @@ export const useAuthStore = create<AuthState>((set) => ({
   isLoading: false,
   isAuthChecked: false,
   error: null,
+
+  expireSession: () => {
+    clearLegacyAuthStorage();
+    set({
+      user: null,
+      isAuthenticated: false,
+      isAuthChecked: true,
+      error: null,
+      isLoading: false,
+    });
+  },
 
   login: async (login: string, password: string) => {
     set({ isLoading: true, error: null });
@@ -81,13 +93,28 @@ export const useAuthStore = create<AuthState>((set) => ({
   },
 
   loadProfile: async () => {
-    const { data } = await api.get('/auth/profile');
+    try {
+      const { data } = await api.get('/auth/profile');
 
-    set({
-      user: data,
-      isAuthenticated: true,
-      isAuthChecked: true,
-    });
+      set({
+        user: data,
+        isAuthenticated: true,
+        isAuthChecked: true,
+        error: null,
+      });
+    } catch (err: unknown) {
+      if (axios.isAxiosError(err) && err.response?.status === 401) {
+        clearLegacyAuthStorage();
+        set({
+          user: null,
+          isAuthenticated: false,
+          isAuthChecked: true,
+          error: null,
+        });
+      }
+
+      throw err;
+    }
   },
 
   changePassword: async (oldPassword: string, newPassword: string) => {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,12 @@ services:
     depends_on:
       mongodb:
         condition: service_healthy
+    healthcheck:
+      test: "node -e \"fetch('http://127.0.0.1:3000/api').then((response) => process.exit(response.ok ? 0 : 1)).catch(() => process.exit(1))\""
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
     networks:
       - campus
 
@@ -25,14 +31,21 @@ services:
     ports:
       - '5173:80'
     depends_on:
-      - server
+      server:
+        condition: service_healthy
+    healthcheck:
+      test: "wget -q --spider http://127.0.0.1/ || exit 1"
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 10s
     networks:
       - campus
 
   mongodb:
     image: mongo:7.0
-    ports:
-      - '${MONGO_BIND_IP:-127.0.0.1}:${MONGO_PORT:-27017}:27017'
+    expose:
+      - '27017'
     restart: unless-stopped
     environment:
       - MONGO_INITDB_ROOT_USERNAME=${MONGO_ROOT_USERNAME}


### PR DESCRIPTION
## Summary

- Hardened frontend auth/session recovery when API requests return `401`.
- Added explicit expired-session handling with auth state cleanup and safe redirect to `/login`.
- Prevented unhandled profile-loading errors after expired or invalid sessions.
- Added nginx security headers for the production frontend.
- Improved Docker Compose startup reliability with healthchecks for backend and client.
- Kept MongoDB internal to the Docker network by default to avoid local port conflicts and reduce database exposure.
- Updated environment documentation and `.env.example` to match the current secure Docker setup.

## Security

- Added CSP, HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy and Permissions-Policy headers.
- Avoided exposing MongoDB on the host network by default.
- Preserved HttpOnly cookie auth and CSRF-based protection flow.
- Clarified production-safe environment values for Hetzner/GitHub Actions deploys.

## Verification

- `npm audit --audit-level=moderate` in `client` — 0 vulnerabilities.
- `npm audit --audit-level=moderate` in `server` — 0 vulnerabilities.
- `npm run lint` in `client` — passed.
- `npm run lint:check` in `server` — passed.
- `npm run build` in `client` — passed.
- `npm run build` in `server` — passed.
- `npm test` in `server` — 10 suites / 59 tests passed.
- `docker compose up -d --build` — passed.
- `docker compose ps` — client, server and MongoDB are healthy.
- Smoke check: `http://localhost:3000/api` returns API status and `http://localhost:5173` returns `200`.