### PR TITLE
fix(client): address session and CSP review feedback

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -8,9 +8,6 @@ RUN npm ci
 
 COPY . .
 
-ARG VITE_API_URL=/api
-ENV VITE_API_URL=$VITE_API_URL
-
 RUN npm run build
 
 FROM nginx:alpine

--- a/client/src/services/api.ts
+++ b/client/src/services/api.ts
@@ -5,7 +5,7 @@ import axios, {
 } from 'axios';
 
 const api = axios.create({
-  baseURL: import.meta.env.VITE_API_URL?.trim() || '/api',
+  baseURL: '/api',
   withCredentials: true,
 });
 

--- a/client/src/store/authStore.ts
+++ b/client/src/store/authStore.ts
@@ -93,28 +93,14 @@ export const useAuthStore = create<AuthState>((set) => ({
   },
 
   loadProfile: async () => {
-    try {
-      const { data } = await api.get('/auth/profile');
+    const { data } = await api.get('/auth/profile');
 
-      set({
-        user: data,
-        isAuthenticated: true,
-        isAuthChecked: true,
-        error: null,
-      });
-    } catch (err: unknown) {
-      if (axios.isAxiosError(err) && err.response?.status === 401) {
-        clearLegacyAuthStorage();
-        set({
-          user: null,
-          isAuthenticated: false,
-          isAuthChecked: true,
-          error: null,
-        });
-      }
-
-      throw err;
-    }
+    set({
+      user: data,
+      isAuthenticated: true,
+      isAuthChecked: true,
+      error: null,
+    });
   },
 
   changePassword: async (oldPassword: string, newPassword: string) => {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,10 +23,7 @@ services:
       - campus
 
   client:
-    build:
-      context: ./client
-      args:
-        - VITE_API_URL=/api
+    build: ./client
     restart: unless-stopped
     ports:
       - '5173:80'


### PR DESCRIPTION
Rely on the centralized expired-session flow for profile loading and keep frontend API traffic same-origin under /api so nginx CSP connect-src 'self' stays consistent with the Docker deployment model.