### PR TITLE
fix(client): avoid redundant auth checks on login

### DIFF
--- a/client/src/pages/auth/LoginPage.tsx
+++ b/client/src/pages/auth/LoginPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -11,7 +11,13 @@ import LanguageSwitcher from '../../components/LanguageSwitcher';
 export default function LoginPage() {
   const navigate = useNavigate();
   const { t } = useTranslation();
-  const { login: doLogin, isLoading, error } = useAuthStore();
+  const {
+    login: doLogin,
+    isAuthenticated,
+    isAuthChecked,
+    isLoading,
+    error,
+  } = useAuthStore();
   const [showPassword, setShowPassword] = useState(false);
 
   const {
@@ -25,6 +31,12 @@ export default function LoginPage() {
       password: '',
     },
   });
+
+  useEffect(() => {
+    if (isAuthChecked && isAuthenticated) {
+      navigate('/dashboard', { replace: true });
+    }
+  }, [isAuthChecked, isAuthenticated, navigate]);
 
   const onSubmit = async (values: LoginFormData) => {
     try {

--- a/client/src/store/authStore.ts
+++ b/client/src/store/authStore.ts
@@ -3,6 +3,9 @@ import axios from 'axios';
 import api from '../services/api';
 import type { User } from '../types';
 
+const PUBLIC_AUTH_PATHS = ['/login', '/forgot-password', '/reset-password'];
+const CSRF_COOKIE_NAME = 'campus_csrf_token';
+
 interface AuthState {
   user: User | null;
   isAuthenticated: boolean;
@@ -24,6 +27,41 @@ function clearLegacyAuthStorage() {
 
   localStorage.removeItem('accessToken');
   localStorage.removeItem('refreshToken');
+}
+
+function isPublicAuthPage() {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  return PUBLIC_AUTH_PATHS.some((path) =>
+    window.location.pathname.startsWith(path),
+  );
+}
+
+function readCookie(name: string) {
+  if (typeof document === 'undefined') {
+    return null;
+  }
+
+  const cookies = document.cookie.split(';');
+  for (const cookie of cookies) {
+    const separatorIndex = cookie.indexOf('=');
+    if (separatorIndex < 0) {
+      continue;
+    }
+
+    const cookieName = cookie.slice(0, separatorIndex).trim();
+    if (cookieName === name) {
+      return cookie.slice(separatorIndex + 1).trim();
+    }
+  }
+
+  return null;
+}
+
+function hasSessionHint() {
+  return Boolean(readCookie(CSRF_COOKIE_NAME));
 }
 
 export const useAuthStore = create<AuthState>((set) => ({
@@ -129,6 +167,18 @@ export const useAuthStore = create<AuthState>((set) => ({
   },
 
   initializeAuth: async () => {
+    if (isPublicAuthPage() && !hasSessionHint()) {
+      clearLegacyAuthStorage();
+      set({
+        user: null,
+        isAuthenticated: false,
+        isAuthChecked: true,
+        error: null,
+        isLoading: false,
+      });
+      return;
+    }
+
     try {
       const { data } = await api.get('/auth/profile');
 


### PR DESCRIPTION
## Summary

- Skip automatic `/auth/profile` initialization on public auth pages when there is no session cookie hint.
- Prevent redundant `profile 401 → refresh 401` requests on a clean `/login` page.
- Keep existing expired-session handling centralized in the Axios interceptor/event flow.
- Redirect already authenticated users away from `/login` to `/dashboard`.

## Why

The login page was functionally correct, but a clean unauthenticated visit still produced expected-but-noisy `401` responses in DevTools. This keeps the auth flow quieter and more professional without weakening session recovery for protected pages.

## Verification

- `cd client && npm run lint`
- `cd client && npm run build`
- `git diff --check`