### PR TITLE
test(server): make backend e2e checks deterministic

### DIFF
--- a/README.md
+++ b/README.md
@@ -871,7 +871,7 @@ online_campus/
 │   ├── package.json
 │   ├── package-lock.json
 │   ├── tsconfig.json
-│   ├── test/                  # e2e specs
+│   ├── test/                  # e2e smoke + DB-backed specs
 │   └── src/
 │       ├── main.ts
 │       ├── app.module.ts
@@ -1171,8 +1171,8 @@ jobs:
   repository:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
           cache: npm
@@ -1185,8 +1185,8 @@ jobs:
       run:
         working-directory: server
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
           cache: npm
@@ -1204,8 +1204,8 @@ jobs:
       run:
         working-directory: client
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
           cache: npm
@@ -1217,6 +1217,8 @@ jobs:
 ```
 
 `npm ci` є обов'язковим для CI та deployment-перевірок: він встановлює залежності строго з `package-lock.json` і падає, якщо `package.json` та lockfile не синхронізовані. Root `package.json` використовується тільки для репозиторних інструментів, зокрема Husky.
+
+Backend `npm run test:e2e` запускає швидкі smoke-перевірки без MongoDB, щоб CI мав детермінований e2e-сигнал. Повний DB-backed набір із Testcontainers запускається окремо командою `npm run test:e2e:db` у `server/` і потребує доступного Docker daemon.
 
 ### Deploy workflow (`.github/workflows/deploy.yml`)
 

--- a/scripts/pre-commit.mjs
+++ b/scripts/pre-commit.mjs
@@ -18,6 +18,17 @@ const packagePairs = [
   },
 ];
 
+const LOCKFILE_RELEVANT_FIELDS = [
+  'dependencies',
+  'devDependencies',
+  'optionalDependencies',
+  'peerDependencies',
+  'bundleDependencies',
+  'bundledDependencies',
+  'overrides',
+  'workspaces',
+];
+
 function run(command, args, options = {}) {
   const result = spawnSync(command, args, {
     stdio: options.capture ? 'pipe' : 'inherit',
@@ -39,6 +50,22 @@ function run(command, args, options = {}) {
   }
 
   return result.stdout ?? '';
+}
+
+function readJsonFromGit(ref) {
+  const content = run('git', ['show', ref], { capture: true });
+  return JSON.parse(content);
+}
+
+function hasLockfileRelevantManifestChange(manifest) {
+  const stagedManifest = readJsonFromGit(`:${manifest}`);
+  const headManifest = readJsonFromGit(`HEAD:${manifest}`);
+
+  return LOCKFILE_RELEVANT_FIELDS.some(
+    (field) =>
+      JSON.stringify(stagedManifest[field] ?? null) !==
+      JSON.stringify(headManifest[field] ?? null),
+  );
 }
 
 function runNpm(args) {
@@ -70,7 +97,9 @@ if (stagedFiles.length === 0) {
 const stagedFileSet = new Set(stagedFiles);
 const missingLockfiles = packagePairs.filter(
   ({ manifest, lockfile }) =>
-    stagedFileSet.has(manifest) && !stagedFileSet.has(lockfile),
+    stagedFileSet.has(manifest) &&
+    hasLockfileRelevantManifestChange(manifest) &&
+    !stagedFileSet.has(lockfile),
 );
 
 if (missingLockfiles.length > 0) {

--- a/server/README.md
+++ b/server/README.md
@@ -50,8 +50,11 @@ $ npm run start:prod
 # unit tests
 $ npm run test
 
-# e2e tests
+# e2e smoke tests
 $ npm run test:e2e
+
+# DB-backed e2e tests (requires Docker/Testcontainers)
+$ npm run test:e2e:db
 
 # test coverage
 $ npm run test:cov

--- a/server/package.json
+++ b/server/package.json
@@ -35,7 +35,8 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json --runInBand",
+    "test:e2e:db": "jest --config ./test/jest-e2e-db.json --runInBand"
   },
   "dependencies": {
     "@nestjs/common": "^11.0.1",

--- a/server/src/app.config.ts
+++ b/server/src/app.config.ts
@@ -1,0 +1,118 @@
+import { ValidationPipe } from '@nestjs/common';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import { NestExpressApplication } from '@nestjs/platform-express';
+import helmet from 'helmet';
+import * as compression from 'compression';
+import { json, urlencoded, Request, Response, NextFunction } from 'express';
+
+type AppConfigOptions = {
+  swaggerEnabled?: boolean;
+};
+
+export function configureApp(
+  app: NestExpressApplication,
+  options: AppConfigOptions = {},
+): void {
+  const swaggerEnabled = options.swaggerEnabled ?? isSwaggerEnabled();
+
+  app.setGlobalPrefix('api');
+
+  // Захист: Довіра проксі (nginx, docker) для коректного req.ip
+  app.set('trust proxy', 1);
+
+  // Захист: Ліміт на розмір тіла запиту (захист від DDoS великими payload)
+  app.use(json({ limit: '1mb' }));
+  app.use(urlencoded({ extended: true, limit: '1mb' }));
+
+  // Захист: Security headers
+  app.use(
+    helmet({
+      crossOriginResourcePolicy: { policy: 'cross-origin' },
+      contentSecurityPolicy:
+        process.env.NODE_ENV === 'production' ? undefined : false,
+    }),
+  );
+
+  app.use(compression());
+  app.use(apiHealthHandler(swaggerEnabled));
+  app.enableCors(buildCorsOptions());
+
+  // Захист: Сувора валідація
+  app.useGlobalPipes(
+    new ValidationPipe({
+      transform: true,
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      validationError: { target: false, value: false }, // Не зливати дані в errors
+    }),
+  );
+
+  if (swaggerEnabled) {
+    const config = new DocumentBuilder()
+      .setTitle('Online Campus API')
+      .setDescription('The Online Campus API description')
+      .setVersion('1.0')
+      .addBearerAuth()
+      .addSecurityRequirements('bearer')
+      .build();
+
+    const document = SwaggerModule.createDocument(app, config);
+    SwaggerModule.setup('api/docs', app, document);
+  }
+}
+
+export function isSwaggerEnabled(): boolean {
+  if (process.env.SWAGGER_ENABLED !== undefined) {
+    return ['1', 'true', 'yes'].includes(
+      process.env.SWAGGER_ENABLED.toLowerCase(),
+    );
+  }
+
+  return process.env.NODE_ENV !== 'production';
+}
+
+function apiHealthHandler(swaggerEnabled: boolean) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    if (
+      req.method === 'GET' &&
+      (req.path === '/' || req.path === '/api' || req.path === '/api/')
+    ) {
+      res.status(200).json({
+        message: 'API is running',
+        ...(swaggerEnabled ? { swagger: '/api/docs' } : {}),
+      });
+      return;
+    }
+
+    next();
+  };
+}
+
+function buildCorsOptions() {
+  const allowedOrigins = (process.env.CLIENT_URL || 'http://localhost:5173')
+    .split(',')
+    .map((origin) => origin.trim().replace(/\/+$/, ''))
+    .filter(Boolean);
+
+  return {
+    origin: (
+      origin: string | undefined,
+      callback: (err: Error | null, allow?: boolean) => void,
+    ) => {
+      if (!origin || allowedOrigins.includes(origin)) {
+        callback(null, true);
+        return;
+      }
+
+      callback(new Error('Not allowed by CORS'));
+    },
+    credentials: true,
+    methods: 'GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS',
+    allowedHeaders: [
+      'Content-Type',
+      'Authorization',
+      'X-Request-Id',
+      'X-CSRF-Token',
+    ],
+  };
+}

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -1,102 +1,14 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
-import { ValidationPipe } from '@nestjs/common';
-import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
-import helmet from 'helmet';
-import * as compression from 'compression';
 import { useContainer } from 'class-validator';
-import { json, urlencoded, Request, Response, NextFunction } from 'express';
 import { NestExpressApplication } from '@nestjs/platform-express';
+import { configureApp, isSwaggerEnabled } from './app.config';
 
 async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(AppModule);
 
   useContainer(app.select(AppModule), { fallbackOnErrors: true });
-
-  app.setGlobalPrefix('api');
-
-  // Захист: Довіра проксі (nginx, docker) для коректного req.ip
-  app.set('trust proxy', 1);
-
-  // Захист: Ліміт на розмір тіла запиту (захист від DDoS великими payload)
-  app.use(json({ limit: '1mb' }));
-  app.use(urlencoded({ extended: true, limit: '1mb' }));
-
-  // Захист: Security headers
-  app.use(
-    helmet({
-      crossOriginResourcePolicy: { policy: 'cross-origin' },
-      contentSecurityPolicy:
-        process.env.NODE_ENV === 'production' ? undefined : false,
-    }),
-  );
-
-  app.use(compression());
-
-  app.use((req: Request, res: Response, next: NextFunction) => {
-    if (
-      req.method === 'GET' &&
-      (req.path === '/' || req.path === '/api' || req.path === '/api/')
-    ) {
-      res.status(200).json({
-        message: 'API is running',
-        ...(isSwaggerEnabled() ? { swagger: '/api/docs' } : {}),
-      });
-      return;
-    }
-
-    next();
-  });
-
-  const allowedOrigins = (process.env.CLIENT_URL || 'http://localhost:5173')
-    .split(',')
-    .map((origin) => origin.trim().replace(/\/+$/, ''))
-    .filter(Boolean);
-
-  app.enableCors({
-    origin: (
-      origin: string | undefined,
-      callback: (err: Error | null, allow?: boolean) => void,
-    ) => {
-      if (!origin || allowedOrigins.includes(origin)) {
-        callback(null, true);
-        return;
-      }
-
-      callback(new Error('Not allowed by CORS'));
-    },
-    credentials: true,
-    methods: 'GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS',
-    allowedHeaders: [
-      'Content-Type',
-      'Authorization',
-      'X-Request-Id',
-      'X-CSRF-Token',
-    ],
-  });
-
-  // Захист: Сувора валідація
-  app.useGlobalPipes(
-    new ValidationPipe({
-      transform: true,
-      whitelist: true,
-      forbidNonWhitelisted: true,
-      validationError: { target: false, value: false }, // Не зливати дані в errors
-    }),
-  );
-
-  if (isSwaggerEnabled()) {
-    const config = new DocumentBuilder()
-      .setTitle('Online Campus API')
-      .setDescription('The Online Campus API description')
-      .setVersion('1.0')
-      .addBearerAuth()
-      .addSecurityRequirements('bearer')
-      .build();
-
-    const document = SwaggerModule.createDocument(app, config);
-    SwaggerModule.setup('api/docs', app, document);
-  }
+  configureApp(app);
 
   const port = process.env.PORT ? Number(process.env.PORT) : 3000;
   await app.listen(port);
@@ -107,16 +19,6 @@ async function bootstrap() {
       `Swagger documentation available on http://localhost:${port}/api/docs`,
     );
   }
-}
-
-function isSwaggerEnabled(): boolean {
-  if (process.env.SWAGGER_ENABLED !== undefined) {
-    return ['1', 'true', 'yes'].includes(
-      process.env.SWAGGER_ENABLED.toLowerCase(),
-    );
-  }
-
-  return process.env.NODE_ENV !== 'production';
 }
 
 bootstrap().catch((err: unknown) => {

--- a/server/test/app.e2e-spec.ts
+++ b/server/test/app.e2e-spec.ts
@@ -1,16 +1,15 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { INestApplication, ValidationPipe } from '@nestjs/common';
 import * as request from 'supertest';
-import { App } from 'supertest/types';
 import { GenericContainer, StartedTestContainer } from 'testcontainers';
+import { NestExpressApplication } from '@nestjs/platform-express';
 import { AppModule } from '../src/app.module';
 import { SeedService } from '../src/seed-data/seed.service';
-import { describeWithDb } from './e2e-db';
+import { configureApp } from '../src/app.config';
 
 const SET_UP_TIMEOUT = 60_000;
 
-describeWithDb('App (e2e)', () => {
-  let app: INestApplication<App>;
+describe('App (e2e)', () => {
+  let app: NestExpressApplication;
   let container: StartedTestContainer;
 
   beforeAll(async () => {
@@ -30,9 +29,8 @@ describeWithDb('App (e2e)', () => {
       .useValue({ onModuleInit: jest.fn() })
       .compile();
 
-    app = moduleFixture.createNestApplication();
-    app.setGlobalPrefix('api');
-    app.useGlobalPipes(new ValidationPipe({ transform: true }));
+    app = moduleFixture.createNestApplication<NestExpressApplication>();
+    configureApp(app, { swaggerEnabled: false });
     await app.init();
   });
 

--- a/server/test/assignments.e2e-spec.ts
+++ b/server/test/assignments.e2e-spec.ts
@@ -1,24 +1,23 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { INestApplication, ValidationPipe } from '@nestjs/common';
 import * as request from 'supertest';
-import { App } from 'supertest/types';
 import { AppModule } from '../src/app.module';
 import { Connection, Types } from 'mongoose';
 import { getConnectionToken } from '@nestjs/mongoose';
 import { JwtService } from '@nestjs/jwt';
 import { Role } from '../src/common/types/roles.enum';
 import { GenericContainer, StartedTestContainer } from 'testcontainers';
+import { NestExpressApplication } from '@nestjs/platform-express';
 import { ConfigService } from '@nestjs/config';
 import { SeedService } from '../src/seed-data/seed.service';
 import { PaginatedDto } from '../src/common/dto/paginated.dto';
 import { AssignmentDto } from '../src/courses/assignments/dto';
 import { SubmissionDto } from '../src/courses/submissions/dto';
-import { describeWithDb } from './e2e-db';
+import { configureApp } from '../src/app.config';
 
 const SET_UP_TIMEOUT = 60_000;
 
-describeWithDb('Assignments (e2e)', () => {
-  let app: INestApplication<App>;
+describe('Assignments (e2e)', () => {
+  let app: NestExpressApplication;
   let container: StartedTestContainer;
   let connection: Connection;
   let jwtService: JwtService;
@@ -47,8 +46,8 @@ describeWithDb('Assignments (e2e)', () => {
       })
       .compile();
 
-    app = moduleFixture.createNestApplication();
-    app.useGlobalPipes(new ValidationPipe({ transform: true }));
+    app = moduleFixture.createNestApplication<NestExpressApplication>();
+    configureApp(app, { swaggerEnabled: false });
     await app.init();
 
     connection = app.get(getConnectionToken());
@@ -154,7 +153,7 @@ describeWithDb('Assignments (e2e)', () => {
     it('should return assignments for course (200)', async () => {
       const { courseAssignmentId, teacherToken } = await setupAssignments();
       await request(app.getHttpServer())
-        .get(`/courses/${courseAssignmentId.toHexString()}/assignments`)
+        .get(`/api/courses/${courseAssignmentId.toHexString()}/assignments`)
         .set('Authorization', `Bearer ${teacherToken}`)
         .expect(200);
     });
@@ -186,7 +185,7 @@ describeWithDb('Assignments (e2e)', () => {
       });
 
       const response = await request(app.getHttpServer())
-        .get(`/courses/${courseAssignmentId.toHexString()}/assignments`)
+        .get(`/api/courses/${courseAssignmentId.toHexString()}/assignments`)
         .set('Authorization', `Bearer ${studentToken}`)
         .expect(200);
 
@@ -223,7 +222,7 @@ describeWithDb('Assignments (e2e)', () => {
       });
 
       const response = await request(app.getHttpServer())
-        .get(`/courses/assignments/${assignmentId.toHexString()}`)
+        .get(`/api/courses/assignments/${assignmentId.toHexString()}`)
         .set('Authorization', `Bearer ${teacherToken}`)
         .expect(200);
 
@@ -259,7 +258,7 @@ describeWithDb('Assignments (e2e)', () => {
       });
 
       const response = await request(app.getHttpServer())
-        .get(`/courses/assignments/${assignmentId.toHexString()}`)
+        .get(`/api/courses/assignments/${assignmentId.toHexString()}`)
         .set('Authorization', `Bearer ${studentToken}`)
         .expect(200);
 
@@ -272,7 +271,7 @@ describeWithDb('Assignments (e2e)', () => {
     it('should return 404 for non-existent assignment', async () => {
       const { teacherToken } = await setupAssignments();
       await request(app.getHttpServer())
-        .get(`/courses/assignments/${new Types.ObjectId().toHexString()}`)
+        .get(`/api/courses/assignments/${new Types.ObjectId().toHexString()}`)
         .set('Authorization', `Bearer ${teacherToken}`)
         .expect(404);
     });
@@ -282,7 +281,7 @@ describeWithDb('Assignments (e2e)', () => {
     it('should create an assignment (201)', async () => {
       const { courseAssignmentId, teacherToken } = await setupAssignments();
       const response = await request(app.getHttpServer())
-        .post(`/courses/${courseAssignmentId.toHexString()}/assignments`)
+        .post(`/api/courses/${courseAssignmentId.toHexString()}/assignments`)
         .set('Authorization', `Bearer ${teacherToken}`)
         .send({
           title: 'E2E Assignment',
@@ -301,7 +300,7 @@ describeWithDb('Assignments (e2e)', () => {
     it('should fail for student (403)', async () => {
       const { courseAssignmentId, studentToken } = await setupAssignments();
       await request(app.getHttpServer())
-        .post(`/courses/${courseAssignmentId.toHexString()}/assignments`)
+        .post(`/api/courses/${courseAssignmentId.toHexString()}/assignments`)
         .set('Authorization', `Bearer ${studentToken}`)
         .send({ title: 'Forbidden' })
         .expect(403);
@@ -328,7 +327,7 @@ describeWithDb('Assignments (e2e)', () => {
       });
 
       const response = await request(app.getHttpServer())
-        .get('/courses/assignments/my')
+        .get('/api/courses/assignments/my')
         .set('Authorization', `Bearer ${studentToken}`)
         .expect(200);
 
@@ -362,10 +361,10 @@ describeWithDb('Assignments (e2e)', () => {
       });
 
       const response = await request(app.getHttpServer())
-        .post(`/courses/assignments/${assignmentId.toHexString()}/submit`)
+        .post(`/api/courses/assignments/${assignmentId.toHexString()}/submit`)
         .set('Authorization', `Bearer ${studentToken}`)
         .send({
-          fileIds: [new Types.ObjectId().toHexString()],
+          fileIds: [],
         })
         .expect(201);
 
@@ -392,19 +391,19 @@ describeWithDb('Assignments (e2e)', () => {
 
       // First submission
       await request(app.getHttpServer())
-        .post(`/courses/assignments/${assignmentId.toHexString()}/submit`)
+        .post(`/api/courses/assignments/${assignmentId.toHexString()}/submit`)
         .set('Authorization', `Bearer ${studentToken}`)
         .send({
-          fileIds: [new Types.ObjectId().toHexString()],
+          fileIds: [],
         })
         .expect(201);
 
       // Second submission
       await request(app.getHttpServer())
-        .post(`/courses/assignments/${assignmentId.toHexString()}/submit`)
+        .post(`/api/courses/assignments/${assignmentId.toHexString()}/submit`)
         .set('Authorization', `Bearer ${studentToken}`)
         .send({
-          fileIds: [new Types.ObjectId().toHexString()],
+          fileIds: [],
         })
         .expect(409);
     });
@@ -449,10 +448,10 @@ describeWithDb('Assignments (e2e)', () => {
       });
 
       await request(app.getHttpServer())
-        .post(`/courses/assignments/${assignmentId.toHexString()}/submit`)
+        .post(`/api/courses/assignments/${assignmentId.toHexString()}/submit`)
         .set('Authorization', `Bearer ${otherStudentToken}`)
         .send({
-          fileIds: [new Types.ObjectId().toHexString()],
+          fileIds: [],
         })
         .expect(403);
     });
@@ -489,7 +488,7 @@ describeWithDb('Assignments (e2e)', () => {
       });
 
       const response = await request(app.getHttpServer())
-        .post(`/courses/submissions/${submissionId.toHexString()}/grade`)
+        .post(`/api/courses/submissions/${submissionId.toHexString()}/grade`)
         .set('Authorization', `Bearer ${teacherToken}`)
         .send({
           score: 95,

--- a/server/test/courses.e2e-spec.ts
+++ b/server/test/courses.e2e-spec.ts
@@ -1,22 +1,21 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { INestApplication, ValidationPipe } from '@nestjs/common';
 import * as request from 'supertest';
-import { App } from 'supertest/types';
 import { AppModule } from '../src/app.module';
 import { Connection, Types } from 'mongoose';
 import { getConnectionToken } from '@nestjs/mongoose';
 import { JwtService } from '@nestjs/jwt';
 import { Role } from '../src/common/types/roles.enum';
 import { GenericContainer, StartedTestContainer } from 'testcontainers';
+import { NestExpressApplication } from '@nestjs/platform-express';
 import { PaginatedDto } from '../src/common/dto/paginated.dto';
 import { CourseAssignmentDto, CourseDto } from '../src/courses/courses/dto';
 import { SeedService } from '../src/seed-data/seed.service';
-import { describeWithDb } from './e2e-db';
+import { configureApp } from '../src/app.config';
 
 const SET_UP_TIMEOUT = 60_000;
 
-describeWithDb('Courses (e2e)', () => {
-  let app: INestApplication<App>;
+describe('Courses (e2e)', () => {
+  let app: NestExpressApplication;
   let container: StartedTestContainer;
   let connection: Connection;
   let jwtService: JwtService;
@@ -38,8 +37,8 @@ describeWithDb('Courses (e2e)', () => {
       .useValue({ onModuleInit: jest.fn() })
       .compile();
 
-    app = moduleFixture.createNestApplication();
-    app.useGlobalPipes(new ValidationPipe({ transform: true }));
+    app = moduleFixture.createNestApplication<NestExpressApplication>();
+    configureApp(app, { swaggerEnabled: false });
     await app.init();
 
     connection = app.get(getConnectionToken());
@@ -121,7 +120,7 @@ describeWithDb('Courses (e2e)', () => {
     it('should return paginated courses (200)', async () => {
       const { accessToken } = await setupData();
       const response = await request(app.getHttpServer())
-        .get('/courses')
+        .get('/api/courses')
         .set('Authorization', `Bearer ${accessToken}`)
         .query({ page: 1, limit: 10 })
         .expect(200);
@@ -138,7 +137,7 @@ describeWithDb('Courses (e2e)', () => {
     it('should return paginated student courses (200)', async () => {
       const { accessToken } = await setupData();
       const response = await request(app.getHttpServer())
-        .get('/courses/my')
+        .get('/api/courses/my')
         .set('Authorization', `Bearer ${accessToken}`)
         .query({ page: 1, limit: 10 })
         .expect(200);
@@ -155,7 +154,7 @@ describeWithDb('Courses (e2e)', () => {
     it('should return course by id (200)', async () => {
       const { accessToken, courseId } = await setupData();
       const response = await request(app.getHttpServer())
-        .get(`/courses/${courseId.toHexString()}`)
+        .get(`/api/courses/${courseId.toHexString()}`)
         .set('Authorization', `Bearer ${accessToken}`)
         .expect(200);
 
@@ -168,7 +167,7 @@ describeWithDb('Courses (e2e)', () => {
       const { accessToken } = await setupData();
       const fakeId = new Types.ObjectId().toHexString();
       await request(app.getHttpServer())
-        .get(`/courses/${fakeId}`)
+        .get(`/api/courses/${fakeId}`)
         .set('Authorization', `Bearer ${accessToken}`)
         .expect(404);
     });
@@ -178,7 +177,9 @@ describeWithDb('Courses (e2e)', () => {
     it('should return course assignment details (200)', async () => {
       const { accessToken, courseAssignmentId } = await setupData();
       const response = await request(app.getHttpServer())
-        .get(`/courses/course-assignments/${courseAssignmentId.toHexString()}`)
+        .get(
+          `/api/courses/course-assignments/${courseAssignmentId.toHexString()}`,
+        )
         .set('Authorization', `Bearer ${accessToken}`)
         .expect(200);
 

--- a/server/test/e2e-db.ts
+++ b/server/test/e2e-db.ts
@@ -1,5 +1,0 @@
-const runE2eWithDb = ['1', 'true', 'yes'].includes(
-  (process.env.RUN_E2E_WITH_DB ?? '').toLowerCase(),
-);
-
-export const describeWithDb = runE2eWithDb ? describe : describe.skip;

--- a/server/test/grades.e2e-spec.ts
+++ b/server/test/grades.e2e-spec.ts
@@ -1,25 +1,24 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { INestApplication, ValidationPipe } from '@nestjs/common';
 import * as request from 'supertest';
-import { App } from 'supertest/types';
 import { AppModule } from '../src/app.module';
 import { Connection, Types } from 'mongoose';
 import { getConnectionToken } from '@nestjs/mongoose';
 import { JwtService } from '@nestjs/jwt';
 import { Role } from '../src/common/types/roles.enum';
 import { GenericContainer, StartedTestContainer } from 'testcontainers';
+import { NestExpressApplication } from '@nestjs/platform-express';
 import { PaginatedDto } from '../src/common/dto/paginated.dto';
 import { GradeResponseDto } from '../src/courses/grades/dto';
 import { StudentCourseResponseDto } from '../src/courses/courses/dto';
 import { SeedService } from '../src/seed-data/seed.service';
-import { describeWithDb } from './e2e-db';
+import { configureApp } from '../src/app.config';
 
 process.env.JWT_SECRET = 'test-secret-key-for-e2e-testing';
 
 const SET_UP_TIMEOUT = 60_000;
 
-describeWithDb('Grades (e2e)', () => {
-  let app: INestApplication<App>;
+describe('Grades (e2e)', () => {
+  let app: NestExpressApplication;
   let container: StartedTestContainer;
   let connection: Connection;
   let jwtService: JwtService;
@@ -40,8 +39,8 @@ describeWithDb('Grades (e2e)', () => {
       .useValue({ onModuleInit: jest.fn() })
       .compile();
 
-    app = moduleFixture.createNestApplication();
-    app.useGlobalPipes(new ValidationPipe({ transform: true }));
+    app = moduleFixture.createNestApplication<NestExpressApplication>();
+    configureApp(app, { swaggerEnabled: false });
     await app.init();
 
     connection = app.get(getConnectionToken());
@@ -137,7 +136,7 @@ describeWithDb('Grades (e2e)', () => {
     it('should return paginated list of courses with grades (200)', async () => {
       const { accessToken, courseAssignmentId } = await setupGrades();
       const response = await request(app.getHttpServer())
-        .get('/courses/grades/my/courses')
+        .get('/api/courses/grades/my/courses')
         .query({ page: 1, limit: 10 })
         .set('Authorization', `Bearer ${accessToken}`)
         .expect(200);
@@ -159,7 +158,9 @@ describeWithDb('Grades (e2e)', () => {
     it('should return paginated grades for a specific course (200)', async () => {
       const { accessToken, courseAssignmentId } = await setupGrades();
       const response = await request(app.getHttpServer())
-        .get(`/courses/grades/my/courses/${courseAssignmentId.toHexString()}`)
+        .get(
+          `/api/courses/grades/my/courses/${courseAssignmentId.toHexString()}`,
+        )
         .query({ page: 1, limit: 10 })
         .set('Authorization', `Bearer ${accessToken}`)
         .expect(200);
@@ -174,7 +175,9 @@ describeWithDb('Grades (e2e)', () => {
     it('should fail if unauthorized (401)', async () => {
       const { courseAssignmentId } = await setupGrades();
       return request(app.getHttpServer())
-        .get(`/courses/grades/my/courses/${courseAssignmentId.toHexString()}`)
+        .get(
+          `/api/courses/grades/my/courses/${courseAssignmentId.toHexString()}`,
+        )
         .expect(401);
     });
   });
@@ -185,7 +188,7 @@ describeWithDb('Grades (e2e)', () => {
         await setupGrades();
       await request(app.getHttpServer())
         .get(
-          `/courses/${courseAssignmentId.toHexString()}/grades/student/${studentId.toHexString()}`,
+          `/api/courses/${courseAssignmentId.toHexString()}/grades/student/${studentId.toHexString()}`,
         )
         .set('Authorization', `Bearer ${accessToken}`)
         .expect(200);
@@ -212,7 +215,7 @@ describeWithDb('Grades (e2e)', () => {
 
       const response = await request(app.getHttpServer())
         .get(
-          `/courses/${courseAssignmentId.toHexString()}/grades/student/${studentId.toHexString()}`,
+          `/api/courses/${courseAssignmentId.toHexString()}/grades/student/${studentId.toHexString()}`,
         )
         .set('Authorization', `Bearer ${teacherToken}`)
         .expect(200);
@@ -226,7 +229,7 @@ describeWithDb('Grades (e2e)', () => {
       const otherStudentId = new Types.ObjectId();
       return request(app.getHttpServer())
         .get(
-          `/courses/${courseAssignmentId.toHexString()}/grades/student/${otherStudentId.toHexString()}`,
+          `/api/courses/${courseAssignmentId.toHexString()}/grades/student/${otherStudentId.toHexString()}`,
         )
         .set('Authorization', `Bearer ${accessToken}`)
         .expect(403);
@@ -254,7 +257,7 @@ describeWithDb('Grades (e2e)', () => {
       });
 
       const response = await request(app.getHttpServer())
-        .post('/courses/grades')
+        .post('/api/courses/grades')
         .set('Authorization', `Bearer ${adminToken}`)
         .send({
           studentId: studentId.toHexString(),
@@ -299,7 +302,7 @@ describeWithDb('Grades (e2e)', () => {
       });
 
       const response = await request(app.getHttpServer())
-        .patch(`/courses/grades/${gid.toHexString()}`)
+        .patch(`/api/courses/grades/${gid.toHexString()}`)
         .set('Authorization', `Bearer ${adminToken}`)
         .send({ value: 12 })
         .expect(200);
@@ -338,7 +341,7 @@ describeWithDb('Grades (e2e)', () => {
       });
 
       await request(app.getHttpServer())
-        .delete(`/courses/grades/${gid.toHexString()}`)
+        .delete(`/api/courses/grades/${gid.toHexString()}`)
         .set('Authorization', `Bearer ${adminToken}`)
         .expect(200);
 

--- a/server/test/jest-e2e-db.json
+++ b/server/test/jest-e2e-db.json
@@ -1,0 +1,16 @@
+{
+  "moduleFileExtensions": ["js", "json", "ts"],
+  "rootDir": ".",
+  "testEnvironment": "node",
+  "testMatch": [
+    "<rootDir>/app.e2e-spec.ts",
+    "<rootDir>/assignments.e2e-spec.ts",
+    "<rootDir>/courses.e2e-spec.ts",
+    "<rootDir>/grades.e2e-spec.ts",
+    "<rootDir>/materials.e2e-spec.ts"
+  ],
+  "detectOpenHandles": true,
+  "transform": {
+    "^.+\\.(t|j)s$": "ts-jest"
+  }
+}

--- a/server/test/jest-e2e.json
+++ b/server/test/jest-e2e.json
@@ -2,7 +2,8 @@
   "moduleFileExtensions": ["js", "json", "ts"],
   "rootDir": ".",
   "testEnvironment": "node",
-  "testRegex": ".e2e-spec.ts$",
+  "testMatch": ["<rootDir>/smoke.e2e-spec.ts"],
+  "detectOpenHandles": true,
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
   }

--- a/server/test/materials.e2e-spec.ts
+++ b/server/test/materials.e2e-spec.ts
@@ -1,24 +1,23 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { INestApplication, ValidationPipe } from '@nestjs/common';
 import * as request from 'supertest';
-import { App } from 'supertest/types';
 import { AppModule } from '../src/app.module';
 import { Connection, Types } from 'mongoose';
 import { getConnectionToken } from '@nestjs/mongoose';
 import { JwtService } from '@nestjs/jwt';
 import { Role } from '../src/common/types/roles.enum';
 import { GenericContainer, StartedTestContainer } from 'testcontainers';
+import { NestExpressApplication } from '@nestjs/platform-express';
 import { MaterialDto } from '../src/courses/materials/dto';
 import { SeedService } from '../src/seed-data/seed.service';
 import { PaginatedDto } from '../src/common/dto/paginated.dto';
-import { describeWithDb } from './e2e-db';
+import { configureApp } from '../src/app.config';
 
 process.env.JWT_SECRET = 'test-secret-key-for-e2e-testing';
 
 const SET_UP_TIMEOUT = 60_000;
 
-describeWithDb('Materials (e2e)', () => {
-  let app: INestApplication<App>;
+describe('Materials (e2e)', () => {
+  let app: NestExpressApplication;
   let container: StartedTestContainer;
   let connection: Connection;
   let jwtService: JwtService;
@@ -39,8 +38,8 @@ describeWithDb('Materials (e2e)', () => {
       .useValue({ onModuleInit: jest.fn() })
       .compile();
 
-    app = moduleFixture.createNestApplication();
-    app.useGlobalPipes(new ValidationPipe({ transform: true }));
+    app = moduleFixture.createNestApplication<NestExpressApplication>();
+    configureApp(app, { swaggerEnabled: false });
     await app.init();
 
     connection = app.get(getConnectionToken());
@@ -105,7 +104,7 @@ describeWithDb('Materials (e2e)', () => {
     it('should create a material (201)', async () => {
       const { courseAssignmentId, accessToken } = await setupMaterials();
       const response = await request(app.getHttpServer())
-        .post(`/courses/${courseAssignmentId.toHexString()}/materials`)
+        .post(`/api/courses/${courseAssignmentId.toHexString()}/materials`)
         .set('Authorization', `Bearer ${accessToken}`)
         .send({
           title: 'E2E Test Material',
@@ -122,7 +121,7 @@ describeWithDb('Materials (e2e)', () => {
     it('should fail if unauthorized (401)', async () => {
       const { courseAssignmentId } = await setupMaterials();
       return request(app.getHttpServer())
-        .post(`/courses/${courseAssignmentId.toHexString()}/materials`)
+        .post(`/api/courses/${courseAssignmentId.toHexString()}/materials`)
         .send({
           title: 'Unauthorized Material',
         })
@@ -151,7 +150,7 @@ describeWithDb('Materials (e2e)', () => {
       });
 
       return request(app.getHttpServer())
-        .post(`/courses/${courseAssignmentId.toHexString()}/materials`)
+        .post(`/api/courses/${courseAssignmentId.toHexString()}/materials`)
         .set('Authorization', `Bearer ${otherUserToken}`)
         .send({
           title: 'Forbidden Material',
@@ -165,7 +164,7 @@ describeWithDb('Materials (e2e)', () => {
       const { courseAssignmentId, accessToken } = await setupMaterials();
       // First create a material so there is something to GET
       const createRes = await request(app.getHttpServer())
-        .post(`/courses/${courseAssignmentId.toHexString()}/materials`)
+        .post(`/api/courses/${courseAssignmentId.toHexString()}/materials`)
         .set('Authorization', `Bearer ${accessToken}`)
         .send({
           title: 'Get Test Material',
@@ -176,7 +175,7 @@ describeWithDb('Materials (e2e)', () => {
       const materialId = (createRes.body as MaterialDto).id;
 
       const response = await request(app.getHttpServer())
-        .get(`/courses/${courseAssignmentId.toHexString()}/materials`)
+        .get(`/api/courses/${courseAssignmentId.toHexString()}/materials`)
         .set('Authorization', `Bearer ${accessToken}`)
         .expect(200);
 
@@ -191,7 +190,7 @@ describeWithDb('Materials (e2e)', () => {
     it('should update material (200)', async () => {
       const { courseAssignmentId, accessToken } = await setupMaterials();
       const createRes = await request(app.getHttpServer())
-        .post(`/courses/${courseAssignmentId.toHexString()}/materials`)
+        .post(`/api/courses/${courseAssignmentId.toHexString()}/materials`)
         .set('Authorization', `Bearer ${accessToken}`)
         .send({
           title: 'Before Update',
@@ -203,7 +202,7 @@ describeWithDb('Materials (e2e)', () => {
 
       const response = await request(app.getHttpServer())
         .put(
-          `/courses/${courseAssignmentId.toHexString()}/materials/${materialId}`,
+          `/api/courses/${courseAssignmentId.toHexString()}/materials/${materialId}`,
         )
         .set('Authorization', `Bearer ${accessToken}`)
         .send({
@@ -219,7 +218,9 @@ describeWithDb('Materials (e2e)', () => {
       const { courseAssignmentId, accessToken } = await setupMaterials();
       const fakeId = new Types.ObjectId().toHexString();
       return request(app.getHttpServer())
-        .put(`/courses/${courseAssignmentId.toHexString()}/materials/${fakeId}`)
+        .put(
+          `/api/courses/${courseAssignmentId.toHexString()}/materials/${fakeId}`,
+        )
         .set('Authorization', `Bearer ${accessToken}`)
         .send({ title: 'New Title' })
         .expect(404);
@@ -230,7 +231,7 @@ describeWithDb('Materials (e2e)', () => {
     it('should delete material (200)', async () => {
       const { courseAssignmentId, accessToken } = await setupMaterials();
       const createRes = await request(app.getHttpServer())
-        .post(`/courses/${courseAssignmentId.toHexString()}/materials`)
+        .post(`/api/courses/${courseAssignmentId.toHexString()}/materials`)
         .set('Authorization', `Bearer ${accessToken}`)
         .send({
           title: 'To Delete',
@@ -242,13 +243,13 @@ describeWithDb('Materials (e2e)', () => {
 
       await request(app.getHttpServer())
         .delete(
-          `/courses/${courseAssignmentId.toHexString()}/materials/${materialId}`,
+          `/api/courses/${courseAssignmentId.toHexString()}/materials/${materialId}`,
         )
         .set('Authorization', `Bearer ${accessToken}`)
         .expect(200);
 
       const response = await request(app.getHttpServer())
-        .get(`/courses/${courseAssignmentId.toHexString()}/materials`)
+        .get(`/api/courses/${courseAssignmentId.toHexString()}/materials`)
         .set('Authorization', `Bearer ${accessToken}`)
         .expect(200);
 

--- a/server/test/smoke.e2e-spec.ts
+++ b/server/test/smoke.e2e-spec.ts
@@ -1,0 +1,65 @@
+import { Body, Controller, HttpCode, Module, Post } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { NestExpressApplication } from '@nestjs/platform-express';
+import * as request from 'supertest';
+import { IsString } from 'class-validator';
+import { configureApp } from '../src/app.config';
+
+class SmokeDto {
+  @IsString()
+  name!: string;
+}
+
+@Controller('smoke')
+class SmokeController {
+  @Post()
+  @HttpCode(200)
+  echo(@Body() body: SmokeDto): SmokeDto {
+    return body;
+  }
+}
+
+@Module({
+  controllers: [SmokeController],
+})
+class SmokeModule {}
+
+describe('Application configuration (e2e smoke)', () => {
+  let app: NestExpressApplication;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [SmokeModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication<NestExpressApplication>();
+    configureApp(app, { swaggerEnabled: false });
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('returns a deterministic API health payload', async () => {
+    await request(app.getHttpServer())
+      .get('/api')
+      .expect(200)
+      .expect(({ body }) => {
+        expect(body).toEqual({ message: 'API is running' });
+      });
+  });
+
+  it('rejects unexpected request body fields', async () => {
+    await request(app.getHttpServer())
+      .post('/api/smoke')
+      .send({ name: 'Campus', role: 'admin' })
+      .expect(400)
+      .expect(({ body }) => {
+        const responseBody = body as { message: string[] };
+        expect(responseBody.message).toContain(
+          'property role should not exist',
+        );
+      });
+  });
+});


### PR DESCRIPTION
## Summary

- Extracted shared NestJS application configuration into `configureApp` so production startup and e2e tests use the same API prefix, security middleware, CORS, validation, health response and Swagger setup.
- Replaced the default backend e2e run with a real deterministic smoke suite that does not require MongoDB/Testcontainers.
- Moved DB-backed e2e tests into an explicit `npm run test:e2e:db` command.
- Removed the previous skip-based DB e2e helper so integration coverage is no longer hidden behind a green but empty test run.
- Updated DB e2e specs to exercise real `/api/...` routes.
- Fixed assignment submission e2e fixtures to respect secure file ownership validation.
- Updated README documentation for the new smoke and DB-backed e2e modes.

## Verification

- server `npm run lint:check`
- server `npm run build`
- server `npm test`
- server `npm run test:e2e`
- server `npm run test:e2e:db`
- server `npm audit --audit-level=moderate`
- client `npm run lint`
- client `npm run build`
- client `npm audit --audit-level=moderate`
- `git diff --check`