### PR TITLE
fix(server): complete MongoDB migration hardening

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,7 +22,7 @@ AUTH_COOKIE_SAMESITE=strict
 # local HTTP development: false, HTTPS/dev-server/prod: true
 AUTH_COOKIE_SECURE=false
 PASSWORD_RESET_TTL_MINUTES=30
-# dev-only reset link: відображати токен скидання у відповіді API, якщо доставку електронної пошти не налаштовано
+# dev-only reset link: display a reset token in the API response if email delivery is not configured
 PASSWORD_RESET_EXPOSE_TOKEN=true
 
 # Database
@@ -34,3 +34,10 @@ MONGO_PORT=27017
 MONGO_RETRY_ATTEMPTS=20
 MONGO_RETRY_DELAY_MS=3000
 MONGO_SERVER_SELECTION_TIMEOUT_MS=5000
+
+# Demo fixtures
+# Enables seeders that copy mock fixture data into MongoDB.
+# Keep false in shared dev/prod environments because demo users use a known password.
+SEED_DEMO_DATA=false
+# Never enable in production except for disposable demo databases.
+SEED_DEMO_DATA_IN_PRODUCTION=false

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@
 │                                                          │
 │  ┌──────────────────────────────────────────────────┐   │
 │  │                 DATA LAYER                        │   │
-│  │  In-Memory Mock → MongoDB (Mongoose) [Phase 2]      │   │
+│  │  MongoDB 7 + Mongoose ODM                         │   │
 │  └──────────────────────────────────────────────────┘   │
 └─────────────────────────────────────────────────────────┘
 ```
@@ -99,7 +99,7 @@
 | **API Client**   | Axios-інстанс з cookie-based session interceptors       |
 | **Controller**   | NestJS controllers — прийом HTTP-запитів, валідація DTO |
 | **Service**      | Бізнес-логіка, оркестрація модулів                      |
-| **Data**         | Репозиторії / mock-дані / Mongoose ODM                  |
+| **Data**         | MongoDB collections через Mongoose ODM                  |
 
 ---
 
@@ -789,8 +789,9 @@ Student        (базовий доступ)
 
 ### База даних
 
-- Phase 1: In-memory mock data
-- Phase 2: MongoDB через Mongoose (одна зміна в data layer, бізнес-логіка не змінюється)
+- Phase 1: in-memory mock data — завершено як історичний MVP-етап
+- Phase 2: MongoDB через Mongoose — завершено для runtime-модулів
+- `server/src/common/mock-data` використовується тільки як fixture-source для контрольованих demo seeders, не як runtime data layer
 
 ### Нові типи сповіщень
 
@@ -821,14 +822,14 @@ Student        (базовий доступ)
 
 ### Фаза 2 — База даних + File Upload + Опитування
 
-| #   | Завдання                                            |
-| --- | --------------------------------------------------- |
-| 1   | MongoDB + Mongoose ODM замість mock-даних           |
-| 2   | Міграції схеми                                      |
-| 3   | FileModule — завантаження файлів (матеріали, здачі) |
-| 4   | CRUD для всіх довідників через UI                   |
-| 5   | **SurveysModule** — бекенд + фронтенд (повний цикл) |
-| 6   | Модуль відвідуваності                               |
+| #   | Завдання                                            | Статус       |
+| --- | --------------------------------------------------- | ------------ |
+| 1   | MongoDB + Mongoose ODM замість mock-даних           | ✅ Готово    |
+| 2   | Міграції схеми                                      | ⏳ У роботі  |
+| 3   | FileModule — завантаження файлів (матеріали, здачі) | ✅ Готово    |
+| 4   | CRUD для всіх довідників через UI                   | ⏳ У роботі  |
+| 5   | **SurveysModule** — бекенд + фронтенд (повний цикл) | ✅ Готово    |
+| 6   | Модуль відвідуваності                               | ⏳ Заплановано |
 
 ### Фаза 3 — Production Ready
 
@@ -976,7 +977,7 @@ online_campus/
 │       │   ├── audit-log.service.spec.ts
 │       │   └── audit.interceptor.ts
 │       │
-│       ├── seed/              # demo data seeders
+│       ├── seed-data/         # optional demo data seeders for local fixtures
 │       │   ├── seed.module.ts
 │       │   ├── seed.service.ts
 │       │   └── seeders/
@@ -988,7 +989,7 @@ online_campus/
 │           ├── types/
 │           ├── utils/
 │           ├── validators/
-│           └── mock-data/
+│           └── mock-data/     # seed fixtures only; not used by runtime services
 │
 └── client/                    # React Frontend
     ├── Dockerfile
@@ -1105,10 +1106,20 @@ MONGO_RETRY_ATTEMPTS=20
 MONGO_RETRY_DELAY_MS=3000
 MONGO_SERVER_SELECTION_TIMEOUT_MS=5000
 
+# Demo fixtures
+SEED_DEMO_DATA=false
+SEED_DEMO_DATA_IN_PRODUCTION=false
+
 # Production
 PORT=3000
 NODE_ENV=production
 ```
+
+Demo seeders копіюють fixture-дані з `server/src/common/mock-data` у MongoDB
+лише коли `SEED_DEMO_DATA=true`. У production seeders заблоковані за
+замовчуванням навіть із цим прапорцем; `SEED_DEMO_DATA_IN_PRODUCTION=true`
+дозволено тільки для одноразових demo-баз, бо fixture-користувачі мають відомий
+пароль.
 
 У локальному `docker-compose.yml` MongoDB доступна backend-контейнеру через
 внутрішню Docker network (`mongodb:27017`) і не публікується на host-порт за
@@ -1280,6 +1291,8 @@ jobs:
 | `AUTH_CSRF_BINDING_COOKIE_PATH` | path HttpOnly CSRF binding cookie (`/api` за замовчуванням) |
 | `AUTH_CSRF_HEADER_NAME` | header, який frontend надсилає для unsafe методів (`x-csrf-token`) |
 | `SWAGGER_ENABLED` | `true` для dev, `false`/unset у production; Swagger вимкнений у production за замовчуванням |
+| `SEED_DEMO_DATA` | optional; `true` тільки для локальних fixture-даних, `false`/unset для shared dev/prod |
+| `SEED_DEMO_DATA_IN_PRODUCTION` | emergency/demo-only override; не додавати у production secrets |
 
 ### Правила роботи із залежностями
 
@@ -1360,4 +1373,4 @@ mkdir -p /opt/online_campus && cd /opt/online_campus
 
 ---
 
-_Документ актуальний станом на травень 2026._
+_Документ актуальний станом на червень 2026._

--- a/server/src/courses/schemas/assignment.schema.ts
+++ b/server/src/courses/schemas/assignment.schema.ts
@@ -42,3 +42,5 @@ export class Assignment {
 
 export const AssignmentSchema = SchemaFactory.createForClass(Assignment);
 AssignmentSchema.plugin(paginate);
+AssignmentSchema.index({ courseAssignment: 1, createdAt: -1 });
+AssignmentSchema.index({ group: 1, dueDate: 1 });

--- a/server/src/courses/schemas/course-assignment.schema.ts
+++ b/server/src/courses/schemas/course-assignment.schema.ts
@@ -31,3 +31,10 @@ export const CourseAssignmentSchema =
   SchemaFactory.createForClass(CourseAssignment);
 
 CourseAssignmentSchema.plugin(paginate);
+CourseAssignmentSchema.index({ course: 1 });
+CourseAssignmentSchema.index({ group: 1, academicYear: 1, semester: 1 });
+CourseAssignmentSchema.index({ teacher: 1, academicYear: 1, semester: 1 });
+CourseAssignmentSchema.index(
+  { course: 1, group: 1, academicYear: 1, semester: 1 },
+  { unique: true },
+);

--- a/server/src/courses/schemas/course.schema.ts
+++ b/server/src/courses/schemas/course.schema.ts
@@ -32,3 +32,4 @@ export class Course {
 export const CourseSchema = SchemaFactory.createForClass(Course);
 
 CourseSchema.plugin(paginate);
+CourseSchema.index({ department: 1, semester: 1 });

--- a/server/src/courses/schemas/grade.schema.ts
+++ b/server/src/courses/schemas/grade.schema.ts
@@ -38,3 +38,5 @@ export class Grade {
 
 export const GradeSchema = SchemaFactory.createForClass(Grade);
 GradeSchema.plugin(paginate);
+GradeSchema.index({ student: 1, courseAssignment: 1, date: -1 });
+GradeSchema.index({ courseAssignment: 1, type: 1, date: -1 });

--- a/server/src/courses/schemas/material.schema.ts
+++ b/server/src/courses/schemas/material.schema.ts
@@ -36,3 +36,4 @@ export class Material {
 export const MaterialSchema = SchemaFactory.createForClass(Material);
 
 MaterialSchema.plugin(paginate);
+MaterialSchema.index({ courseAssignment: 1, publishDate: -1 });

--- a/server/src/courses/schemas/submission.schema.ts
+++ b/server/src/courses/schemas/submission.schema.ts
@@ -47,3 +47,6 @@ export class Submission {
 export const SubmissionSchema = SchemaFactory.createForClass(Submission);
 
 SubmissionSchema.plugin(paginate);
+SubmissionSchema.index({ assignment: 1, student: 1 }, { unique: true });
+SubmissionSchema.index({ student: 1, submittedAt: -1 });
+SubmissionSchema.index({ assignment: 1, status: 1, submittedAt: -1 });

--- a/server/src/files/file.schema.ts
+++ b/server/src/files/file.schema.ts
@@ -22,3 +22,6 @@ export class File {
 }
 
 export const FileSchema = SchemaFactory.createForClass(File);
+
+FileSchema.index({ storagePath: 1 }, { unique: true });
+FileSchema.index({ uploadedBy: 1, createdAt: -1 });

--- a/server/src/references/schemas/classroom.schema.ts
+++ b/server/src/references/schemas/classroom.schema.ts
@@ -21,3 +21,6 @@ export class Classroom extends Document {
 }
 
 export const ClassroomSchema = SchemaFactory.createForClass(Classroom);
+
+ClassroomSchema.index({ building: 1, roomNumber: 1 }, { unique: true });
+ClassroomSchema.index({ type: 1 });

--- a/server/src/references/schemas/department.schema.ts
+++ b/server/src/references/schemas/department.schema.ts
@@ -4,7 +4,7 @@ import * as mongoose from 'mongoose';
 import { User } from '../../users/schemas';
 import { Faculty } from './faculty.schema';
 
-@Schema()
+@Schema({ timestamps: true })
 export class Department extends Document {
   @Prop({ required: true })
   name: string;
@@ -21,3 +21,7 @@ export class Department extends Document {
 }
 
 export const DepartmentSchema = SchemaFactory.createForClass(Department);
+
+DepartmentSchema.index({ faculty: 1 });
+DepartmentSchema.index({ head: 1 }, { sparse: true });
+DepartmentSchema.index({ faculty: 1, name: 1 }, { unique: true });

--- a/server/src/references/schemas/faculty.schema.ts
+++ b/server/src/references/schemas/faculty.schema.ts
@@ -3,7 +3,7 @@ import { Document } from 'mongoose';
 import * as mongoose from 'mongoose';
 import { User } from '../../users/schemas';
 
-@Schema()
+@Schema({ timestamps: true })
 export class Faculty extends Document {
   @Prop({ required: true })
   name: string;
@@ -13,3 +13,6 @@ export class Faculty extends Document {
 }
 
 export const FacultySchema = SchemaFactory.createForClass(Faculty);
+
+FacultySchema.index({ name: 1 }, { unique: true });
+FacultySchema.index({ dean: 1 }, { sparse: true });

--- a/server/src/references/schemas/group.schema.ts
+++ b/server/src/references/schemas/group.schema.ts
@@ -4,7 +4,7 @@ import * as mongoose from 'mongoose';
 import { User } from '../../users/schemas';
 import { Specialty } from './specialty.schema';
 
-@Schema()
+@Schema({ timestamps: true })
 export class Group extends Document {
   @Prop({ required: true })
   code: string;
@@ -24,3 +24,7 @@ export class Group extends Document {
 }
 
 export const GroupSchema = SchemaFactory.createForClass(Group);
+
+GroupSchema.index({ code: 1 }, { unique: true });
+GroupSchema.index({ specialty: 1, course: 1 });
+GroupSchema.index({ curator: 1 }, { sparse: true });

--- a/server/src/seed-data/seed.service.spec.ts
+++ b/server/src/seed-data/seed.service.spec.ts
@@ -1,0 +1,117 @@
+import { ConfigService } from '@nestjs/config';
+import { Logger } from '@nestjs/common';
+import { SeedService } from './seed.service';
+
+type SeederMock = {
+  seed: jest.Mock<Promise<void>, []>;
+};
+
+function createSeeder(): SeederMock {
+  const seed = jest.fn<Promise<void>, []>();
+  seed.mockResolvedValue(undefined);
+  return { seed };
+}
+
+function createService(env: Record<string, string | undefined> = {}) {
+  const configService = {
+    get: jest.fn((key: string) => env[key]),
+  } as unknown as ConfigService;
+
+  const seeders = {
+    userSeeder: createSeeder(),
+    facultySeeder: createSeeder(),
+    departmentSeeder: createSeeder(),
+    specialtySeeder: createSeeder(),
+    classroomSeeder: createSeeder(),
+    groupSeeder: createSeeder(),
+    courseSeeder: createSeeder(),
+    courseAssignmentSeeder: createSeeder(),
+    scheduleEntrySeeder: createSeeder(),
+    gradeSeeder: createSeeder(),
+    assignmentSeeder: createSeeder(),
+    materialSeeder: createSeeder(),
+  };
+
+  const service = new SeedService(
+    configService,
+    seeders.userSeeder as never,
+    seeders.facultySeeder as never,
+    seeders.departmentSeeder as never,
+    seeders.specialtySeeder as never,
+    seeders.classroomSeeder as never,
+    seeders.groupSeeder as never,
+    seeders.courseSeeder as never,
+    seeders.courseAssignmentSeeder as never,
+    seeders.scheduleEntrySeeder as never,
+    seeders.gradeSeeder as never,
+    seeders.assignmentSeeder as never,
+    seeders.materialSeeder as never,
+  );
+
+  return { service, seeders };
+}
+
+describe('SeedService', () => {
+  let loggerLogSpy: jest.SpyInstance;
+  let loggerWarnSpy: jest.SpyInstance;
+  let loggerErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    loggerLogSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    loggerWarnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+    loggerErrorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation();
+  });
+
+  afterEach(() => {
+    loggerLogSpy.mockRestore();
+    loggerWarnSpy.mockRestore();
+    loggerErrorSpy.mockRestore();
+  });
+
+  it('does not seed demo data unless explicitly enabled', async () => {
+    const { service, seeders } = createService({ NODE_ENV: 'development' });
+
+    await service.onModuleInit();
+
+    expect(seeders.userSeeder.seed).not.toHaveBeenCalled();
+    expect(seeders.materialSeeder.seed).not.toHaveBeenCalled();
+  });
+
+  it('runs demo seeders in development when enabled', async () => {
+    const { service, seeders } = createService({
+      NODE_ENV: 'development',
+      SEED_DEMO_DATA: 'true',
+    });
+
+    await service.onModuleInit();
+
+    expect(seeders.userSeeder.seed).toHaveBeenCalledTimes(1);
+    expect(seeders.facultySeeder.seed).toHaveBeenCalledTimes(1);
+    expect(seeders.materialSeeder.seed).toHaveBeenCalledTimes(1);
+  });
+
+  it('blocks demo seeding in production by default', async () => {
+    const { service, seeders } = createService({
+      NODE_ENV: 'production',
+      SEED_DEMO_DATA: 'true',
+    });
+
+    await service.onModuleInit();
+
+    expect(seeders.userSeeder.seed).not.toHaveBeenCalled();
+    expect(seeders.materialSeeder.seed).not.toHaveBeenCalled();
+  });
+
+  it('allows production demo seeding only for explicitly disposable environments', async () => {
+    const { service, seeders } = createService({
+      NODE_ENV: 'production',
+      SEED_DEMO_DATA: 'true',
+      SEED_DEMO_DATA_IN_PRODUCTION: 'true',
+    });
+
+    await service.onModuleInit();
+
+    expect(seeders.userSeeder.seed).toHaveBeenCalledTimes(1);
+    expect(seeders.materialSeeder.seed).toHaveBeenCalledTimes(1);
+  });
+});

--- a/server/src/seed-data/seed.service.ts
+++ b/server/src/seed-data/seed.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, OnModuleInit, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import {
   UserSeeder,
   FacultySeeder,
@@ -19,6 +20,7 @@ export class SeedService implements OnModuleInit {
   private readonly logger = new Logger(SeedService.name);
 
   constructor(
+    private readonly configService: ConfigService,
     private readonly userSeeder: UserSeeder,
     private readonly facultySeeder: FacultySeeder,
     private readonly departmentSeeder: DepartmentSeeder,
@@ -34,6 +36,20 @@ export class SeedService implements OnModuleInit {
   ) {}
 
   async onModuleInit() {
+    if (!this.isDemoSeedEnabled()) {
+      this.logger.log(
+        'Demo database seeding is disabled. Set SEED_DEMO_DATA=true only for local development fixtures.',
+      );
+      return;
+    }
+
+    if (this.isProduction() && !this.isProductionDemoSeedAllowed()) {
+      this.logger.warn(
+        'Demo database seeding was requested in production and blocked. Set SEED_DEMO_DATA_IN_PRODUCTION=true only for disposable demo environments.',
+      );
+      return;
+    }
+
     this.logger.log('Checking database for seeding...');
     await this.seed();
   }
@@ -58,6 +74,25 @@ export class SeedService implements OnModuleInit {
       this.logger.log('Seeding process completed.');
     } catch (error) {
       this.logger.error('Error during seeding:', error);
+      throw error;
     }
   }
+
+  private isDemoSeedEnabled(): boolean {
+    return isTruthy(this.configService.get<string>('SEED_DEMO_DATA'));
+  }
+
+  private isProduction(): boolean {
+    return this.configService.get<string>('NODE_ENV') === 'production';
+  }
+
+  private isProductionDemoSeedAllowed(): boolean {
+    return isTruthy(
+      this.configService.get<string>('SEED_DEMO_DATA_IN_PRODUCTION'),
+    );
+  }
+}
+
+function isTruthy(value: string | undefined): boolean {
+  return ['1', 'true', 'yes'].includes((value ?? '').toLowerCase());
 }


### PR DESCRIPTION
## Summary

- Confirmed that runtime backend modules use MongoDB/Mongoose instead of in-memory mock data.
- Disabled demo database seeding by default to prevent accidental creation of fixture users with known passwords.
- Added explicit `SEED_DEMO_DATA` and production safety guard via `SEED_DEMO_DATA_IN_PRODUCTION`.
- Added unit coverage for safe seed behavior across development and production modes.
- Added MongoDB indexes, timestamps and uniqueness constraints for references, academic collections, submissions and files.
- Updated README architecture and phase documentation to mark the MongoDB/Mongoose runtime migration as complete.
- Documented that `common/mock-data` is now only a fixture source for optional local/demo seeders.

## Verification

- server `npm run lint:check`
- server `npm run build`
- server `npm test`
- server `npm run test:e2e`
- server `npm run test:e2e:db`
- server `npm audit --audit-level=moderate`
- client `npm run lint`
- client `npm run build`
- client `npm audit --audit-level=moderate`
- `git diff --check`