### PR TITLE
fix(assignments): sync grade edits across teacher and student workflows (Resolves #28, #30-35)

### DIFF
--- a/client/src/pages/course/CourseDetailPage.tsx
+++ b/client/src/pages/course/CourseDetailPage.tsx
@@ -6,7 +6,7 @@ import type {
   SetStateAction,
   SyntheticEvent,
 } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useParams, useSearchParams } from 'react-router-dom';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   ArrowLeft,
@@ -50,6 +50,20 @@ type TabType =
   | 'submissions'
   | 'grades';
 type AttendanceStatus = 'present' | 'absent' | 'late' | 'excused';
+
+const COURSE_DETAIL_TABS: TabType[] = [
+  'materials',
+  'assignments',
+  'students',
+  'journal',
+  'submissions',
+  'grades',
+];
+
+const getInitialTab = (value: string | null): TabType =>
+  COURSE_DETAIL_TABS.includes(value as TabType)
+    ? (value as TabType)
+    : 'materials';
 
 const MATERIAL_CATEGORY_VALUES: MaterialCategory[] = [
   'lecture',
@@ -157,11 +171,14 @@ async function uploadFile(file: File) {
 
 export default function CourseDetailPage() {
   const { id } = useParams<{ id: string }>();
+  const [searchParams] = useSearchParams();
   const { t, i18n } = useTranslation();
   const queryClient = useQueryClient();
   const { user } = useAuthStore();
   const locale = i18n.language === 'en' ? 'en-US' : 'uk-UA';
-  const [activeTab, setActiveTab] = useState<TabType>('materials');
+  const initialTab = getInitialTab(searchParams.get('tab'));
+  const initialAssignmentId = searchParams.get('assignmentId') ?? '';
+  const [activeTab, setActiveTab] = useState<TabType>(initialTab);
   const [statusMessage, setStatusMessage] = useState('');
   const [materialForm, setMaterialForm] = useState(emptyMaterialForm);
   const [materialFile, setMaterialFile] = useState<File | null>(null);
@@ -184,7 +201,7 @@ export default function CourseDetailPage() {
   const [editingGradeId, setEditingGradeId] = useState<string | null>(null);
   const [gradeEditForm, setGradeEditForm] = useState(emptyGradeEditForm);
   const [selectedSubmissionAssignmentId, setSelectedSubmissionAssignmentId] =
-    useState('');
+    useState(initialAssignmentId);
   const [submissionGradeForm, setSubmissionGradeForm] = useState<
     Record<string, { score: string; comment: string }>
   >({});

--- a/client/src/pages/student/AssignmentsPage.tsx
+++ b/client/src/pages/student/AssignmentsPage.tsx
@@ -245,16 +245,6 @@ export default function AssignmentsPage() {
                       ).toLocaleString(locale)}
                     </span>
                   )}
-                  {assignment.submission?.status === 'graded' &&
-                    assignment.submission.score !== undefined && (
-                      <span className="font-semibold text-green-700">
-                        {t('assignments.gradeResult', {
-                          score: assignment.submission.score,
-                          maxScore: assignment.maxScore,
-                        })}
-                      </span>
-                    )}
-
                   {assignment.submission?.comment && (
                     <div className="mt-1 w-full text-gray-600 italic">
                       <span className="font-medium text-gray-500">

--- a/server/src/courses/assignments/assignments.service.ts
+++ b/server/src/courses/assignments/assignments.service.ts
@@ -329,7 +329,9 @@ export class AssignmentsService {
         type: NotificationType.NEW_ASSIGNMENT,
         targetType: 'group',
         groupId,
-        actionUrl: `/courses/${courseAssignmentId}`,
+        actionUrl: `/courses/${courseAssignmentId}?tab=assignments&assignmentId=${toId(
+          assignment._id,
+        )}`,
         entityType: 'assignment',
         entityId: toId(assignment._id),
         important: true,

--- a/server/src/courses/grades/grades.service.ts
+++ b/server/src/courses/grades/grades.service.ts
@@ -75,11 +75,20 @@ export class GradesService {
       role,
     );
 
+    if (submission.status === 'graded') {
+      this.assertGradeEditableBeforeDeadline(assignment);
+    }
+
     if (dto.score < 0 || dto.score > assignment.maxScore) {
       throw new BadRequestException(
         `Оцінка має бути в межах 0-${assignment.maxScore}`,
       );
     }
+
+    const previousGrade = await this.gradeModel
+      .findOne({ submission: submission._id })
+      .lean()
+      .exec();
 
     submission.score = dto.score;
     submission.comment = dto.comment ?? '';
@@ -87,7 +96,9 @@ export class GradesService {
 
     const saved = await submission.save();
     const grade = await this.upsertSubmissionGrade(saved, assignment, dto);
-    await this.notifySubmissionGraded(grade, assignment, dto.score);
+    if (this.shouldNotifySubmissionGrade(previousGrade, grade)) {
+      await this.notifySubmissionGraded(grade, assignment, dto.score);
+    }
 
     const populated = await saved.populate('files');
     return transformToDto(SubmissionDto, populated.toObject());
@@ -139,16 +150,44 @@ export class GradesService {
       userId,
       role,
     );
+    const linkedAssignment = await this.findLinkedAssignment(grade);
+    if (linkedAssignment) {
+      this.assertGradeEditableBeforeDeadline(linkedAssignment);
+      this.assertGradeFitsAssignmentMaxScore(dto.value, linkedAssignment);
+    }
+
+    const previousGradeSnapshot = {
+      value: grade.value,
+      comment: grade.comment,
+    };
 
     if (dto.type) grade.type = dto.type;
     if (dto.value !== undefined) grade.value = dto.value;
     if (dto.comment !== undefined) grade.comment = dto.comment;
 
     const saved = await grade.save();
-    const populated = await saved.populate({
-      path: 'courseAssignment',
-      populate: { path: 'course' },
-    });
+    if (linkedAssignment) {
+      await this.syncSubmissionFromGrade(saved, linkedAssignment);
+    }
+
+    const populated = await saved.populate([
+      {
+        path: 'courseAssignment',
+        populate: { path: 'course' },
+      },
+      { path: 'assignment' },
+    ]);
+
+    if (
+      linkedAssignment &&
+      this.shouldNotifySubmissionGrade(previousGradeSnapshot, populated)
+    ) {
+      await this.notifySubmissionGraded(
+        populated,
+        linkedAssignment,
+        populated.value,
+      );
+    }
 
     return transformToDto(GradeResponseDto, populated.toObject());
   }
@@ -168,6 +207,11 @@ export class GradesService {
       userId,
       role,
     );
+    const linkedAssignment = await this.findLinkedAssignment(grade);
+    if (linkedAssignment) {
+      this.assertGradeEditableBeforeDeadline(linkedAssignment);
+      await this.resetSubmissionGrade(grade);
+    }
 
     await this.gradeModel.findByIdAndDelete(id).exec();
     return { id };
@@ -383,6 +427,122 @@ export class GradesService {
     return trimmedComment
       ? `Завдання «${assignmentTitle}»: ${trimmedComment}`
       : `Завдання «${assignmentTitle}»`;
+  }
+
+  private shouldNotifySubmissionGrade(
+    previousGrade: { value?: unknown; comment?: unknown } | null,
+    nextGrade: GradeDocument,
+  ): boolean {
+    if (!previousGrade) {
+      return true;
+    }
+
+    const previousComment =
+      typeof previousGrade.comment === 'string' ? previousGrade.comment : '';
+    const nextComment =
+      typeof nextGrade.comment === 'string' ? nextGrade.comment : '';
+
+    return (
+      Number(previousGrade.value) !== nextGrade.value ||
+      previousComment !== nextComment
+    );
+  }
+
+  private async findLinkedAssignment(
+    grade: GradeDocument,
+  ): Promise<AssignmentDocument | null> {
+    if (!grade.assignment) {
+      return null;
+    }
+
+    const assignmentId = toId(grade.assignment);
+    const assignment = await this.assignmentModel.findById(assignmentId).exec();
+    if (!assignment) {
+      return null;
+    }
+
+    return assignment;
+  }
+
+  private assertGradeEditableBeforeDeadline(
+    assignment: AssignmentDocument,
+  ): void {
+    if (new Date() > new Date(assignment.dueDate)) {
+      throw new BadRequestException(
+        'Оцінку за завдання не можна змінювати після дедлайну',
+      );
+    }
+  }
+
+  private assertGradeFitsAssignmentMaxScore(
+    value: number | undefined,
+    assignment: AssignmentDocument,
+  ): void {
+    if (value === undefined) {
+      return;
+    }
+
+    if (value > assignment.maxScore) {
+      throw new BadRequestException(
+        `Оцінка має бути в межах 0-${assignment.maxScore}`,
+      );
+    }
+  }
+
+  private async syncSubmissionFromGrade(
+    grade: GradeDocument,
+    assignment: AssignmentDocument,
+  ): Promise<void> {
+    if (!grade.submission) {
+      return;
+    }
+
+    await this.submissionModel
+      .findByIdAndUpdate(
+        toId(grade.submission),
+        {
+          $set: {
+            score: grade.value,
+            comment: this.extractSubmissionComment(grade.comment, assignment),
+            status: 'graded',
+          },
+        },
+        { runValidators: true },
+      )
+      .exec();
+  }
+
+  private async resetSubmissionGrade(grade: GradeDocument): Promise<void> {
+    if (!grade.submission) {
+      return;
+    }
+
+    await this.submissionModel
+      .findByIdAndUpdate(
+        toId(grade.submission),
+        {
+          $set: { status: 'submitted' },
+          $unset: { score: '', comment: '' },
+        },
+        { runValidators: true },
+      )
+      .exec();
+  }
+
+  private extractSubmissionComment(
+    comment: string | undefined,
+    assignment: AssignmentDocument,
+  ): string {
+    const normalizedComment = comment?.trim() ?? '';
+    const assignmentTitle = assignment.title?.trim() || 'Завдання';
+    const prefixedComment = `Завдання «${assignmentTitle}»:`;
+    const titleOnlyComment = `Завдання «${assignmentTitle}»`;
+
+    if (normalizedComment.startsWith(prefixedComment)) {
+      return normalizedComment.slice(prefixedComment.length).trim();
+    }
+
+    return normalizedComment === titleOnlyComment ? '' : normalizedComment;
   }
 
   private async notifySubmissionGraded(

--- a/server/src/courses/submissions/submissions.service.spec.ts
+++ b/server/src/courses/submissions/submissions.service.spec.ts
@@ -105,11 +105,14 @@ describe('SubmissionsService security checks', () => {
       Role.TEACHER,
     );
     const paginateCall = submissionModel.paginate.mock.calls[0] as [
-      { assignment: Types.ObjectId },
+      { assignment: Types.ObjectId; status: string },
       { populate: unknown },
     ];
 
-    expect(paginateCall[0]).toEqual({ assignment: assignmentId });
+    expect(paginateCall[0]).toEqual({
+      assignment: assignmentId,
+      status: 'submitted',
+    });
     expect(paginateCall[1].populate).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ path: 'student' }),
@@ -140,6 +143,7 @@ describe('SubmissionsService security checks', () => {
       _id: assignmentId,
       group: groupId,
       courseAssignment: objectId(),
+      dueDate: new Date(Date.now() + 60_000),
     };
     const submission = { _id: objectId() };
 
@@ -205,6 +209,68 @@ describe('SubmissionsService security checks', () => {
     ).rejects.toBeInstanceOf(BadRequestException);
 
     expect(assignmentModel.findById).not.toHaveBeenCalled();
+    expect(submissionModel.deleteOne).not.toHaveBeenCalled();
+  });
+
+  it('blocks submissions after the assignment deadline', async () => {
+    const studentId = objectId();
+    const groupId = objectId();
+    const assignment = {
+      _id: objectId(),
+      group: groupId,
+      courseAssignment: objectId(),
+      dueDate: new Date(Date.now() - 60_000),
+    };
+
+    assignmentModel.findById.mockReturnValue(query(assignment));
+    userModel.findById.mockReturnValue(
+      query({
+        studentProfile: { group: groupId },
+      }),
+    );
+
+    await expect(
+      service.submitAssignment(
+        assignment._id.toHexString(),
+        { fileIds: [objectId().toHexString()] },
+        studentId.toHexString(),
+      ),
+    ).rejects.toBeInstanceOf(BadRequestException);
+
+    expect(filesService.assertFilesCanBeAttached).not.toHaveBeenCalled();
+    expect(notificationsService.create).not.toHaveBeenCalled();
+  });
+
+  it('blocks deleting graded submissions for resubmission', async () => {
+    const assignmentId = objectId();
+    const studentId = objectId();
+    const groupId = objectId();
+    const assignment = {
+      _id: assignmentId,
+      group: groupId,
+      courseAssignment: objectId(),
+      dueDate: new Date(Date.now() + 60_000),
+    };
+
+    assignmentModel.findById.mockReturnValue(query(assignment));
+    userModel.findById.mockReturnValue(
+      query({
+        studentProfile: { group: groupId },
+      }),
+    );
+    submissionModel.findOne.mockReturnValue(
+      query({ _id: objectId(), status: 'graded' }),
+    );
+
+    await expect(
+      service.removeSubmission(
+        assignmentId.toHexString(),
+        studentId.toHexString(),
+        studentId.toHexString(),
+        Role.STUDENT,
+      ),
+    ).rejects.toBeInstanceOf(BadRequestException);
+
     expect(submissionModel.deleteOne).not.toHaveBeenCalled();
   });
 });

--- a/server/src/courses/submissions/submissions.service.ts
+++ b/server/src/courses/submissions/submissions.service.ts
@@ -67,7 +67,7 @@ export class SubmissionsService {
     };
 
     const result = await this.submissionModel.paginate(
-      { assignment: assignment._id },
+      { assignment: assignment._id, status: 'submitted' },
       options,
     );
 
@@ -84,11 +84,7 @@ export class SubmissionsService {
       studentId,
       Role.STUDENT,
     );
-    // блокує завантаження після дедлайну, розкоментувати за потребою.
-    // import { BadRequestException } from '@nestjs/common';
-    // if (new Date() > assignment.dueDate) {
-    //   throw new BadRequestException('Термін здачі завдання минув');
-    // }
+    this.assertBeforeDeadline(assignment);
 
     const existingFilter: Record<string, unknown> = {
       assignment: assignment._id,
@@ -134,7 +130,11 @@ export class SubmissionsService {
       throw new BadRequestException('Некоректний ID студента');
     }
 
-    await this.getOwnedAssignment(assignmentId, userId, role);
+    const assignment = await this.getOwnedAssignment(
+      assignmentId,
+      userId,
+      role,
+    );
 
     const filter: Record<string, unknown> = {
       assignment: new Types.ObjectId(assignmentId),
@@ -144,6 +144,16 @@ export class SubmissionsService {
     const existing = await this.submissionModel.findOne(filter).exec();
     if (!existing) {
       throw new NotFoundException('Здану роботу не знайдено');
+    }
+
+    if (role === Role.STUDENT) {
+      this.assertBeforeDeadline(assignment);
+
+      if (existing.status === 'graded') {
+        throw new BadRequestException(
+          'Оцінену роботу не можна видалити для повторної здачі',
+        );
+      }
     }
 
     await this.submissionModel.deleteOne(filter).exec();
@@ -223,7 +233,9 @@ export class SubmissionsService {
           assignment.title
         }»${courseAssignment.courseName ? ` з дисципліни ${courseAssignment.courseName}` : ''}.`,
         type: NotificationType.ASSIGNMENT_SUBMITTED,
-        actionUrl: `/courses/${courseAssignmentId}`,
+        actionUrl: `/courses/${courseAssignmentId}?tab=submissions&assignmentId=${toId(
+          assignment._id,
+        )}`,
         entityType: 'submission',
         entityId: toId(submission._id),
         important: true,
@@ -251,5 +263,11 @@ export class SubmissionsService {
       .trim();
 
     return fullName || user.login || 'Студент';
+  }
+
+  private assertBeforeDeadline(assignment: AssignmentDocument): void {
+    if (new Date() > new Date(assignment.dueDate)) {
+      throw new BadRequestException('Термін здачі завдання минув');
+    }
   }
 }

--- a/server/test/assignments.e2e-spec.ts
+++ b/server/test/assignments.e2e-spec.ts
@@ -420,8 +420,36 @@ describe('Assignments (e2e)', () => {
 
       expect(notification).toBeTruthy();
       expect(notification?.actionUrl).toBe(
-        `/courses/${courseAssignmentId.toHexString()}`,
+        `/courses/${courseAssignmentId.toHexString()}?tab=submissions&assignmentId=${assignmentId.toHexString()}`,
       );
+    });
+
+    it('should reject student submissions after deadline (400)', async () => {
+      const { courseAssignmentId, studentId, studentToken, groupId } =
+        await setupAssignments();
+      const assignmentId = new Types.ObjectId();
+      const fileId = await createUploadedFile(studentId);
+
+      await connection.collection('assignments').insertOne({
+        _id: assignmentId,
+        courseAssignment: courseAssignmentId,
+        group: groupId,
+        title: 'Expired Submit',
+        description: 'Desc',
+        dueDate: new Date(Date.now() - 3600000),
+        maxScore: 100,
+        files: [],
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      await request(app.getHttpServer())
+        .post(`/api/courses/assignments/${assignmentId.toHexString()}/submit`)
+        .set('Authorization', `Bearer ${studentToken}`)
+        .send({
+          fileIds: [fileId.toHexString()],
+        })
+        .expect(400);
     });
 
     it('should fail if submitting twice (409)', async () => {
@@ -558,6 +586,15 @@ describe('Assignments (e2e)', () => {
       expect(body.status).toBe('graded');
       expect(body.score).toBe(95);
 
+      const pendingResponse = await request(app.getHttpServer())
+        .get(
+          `/api/courses/assignments/${assignmentId.toHexString()}/submissions`,
+        )
+        .set('Authorization', `Bearer ${teacherToken}`)
+        .expect(200);
+      const pendingBody = pendingResponse.body as PaginatedDto<SubmissionDto>;
+      expect(pendingBody.docs).toHaveLength(0);
+
       const grade = await connection.collection('grades').findOne({
         submission: submissionId,
         assignment: assignmentId,
@@ -568,6 +605,10 @@ describe('Assignments (e2e)', () => {
       expect(grade).toBeTruthy();
       expect(grade?.value).toBe(95);
       expect(grade?.type).toBe('current');
+      if (!grade?._id) {
+        throw new Error('Expected assignment grade to be created');
+      }
+      const gradeId = grade._id.toHexString();
 
       const notification = await connection
         .collection('notifications')
@@ -575,11 +616,73 @@ describe('Assignments (e2e)', () => {
           userId: studentId,
           type: 'grade',
           entityType: 'grade',
-          entityId: grade?._id.toHexString(),
+          entityId: gradeId,
         });
 
       expect(notification).toBeTruthy();
       expect(notification?.actionUrl).toBe('/assignments');
+
+      await request(app.getHttpServer())
+        .post(`/api/courses/submissions/${submissionId.toHexString()}/grade`)
+        .set('Authorization', `Bearer ${teacherToken}`)
+        .send({
+          score: 95,
+          comment: 'Good job',
+        })
+        .expect(201);
+
+      const gradeNotifications = await connection
+        .collection('notifications')
+        .countDocuments({
+          userId: studentId,
+          type: 'grade',
+          entityType: 'grade',
+          entityId: gradeId,
+        });
+      expect(gradeNotifications).toBe(1);
+
+      await request(app.getHttpServer())
+        .patch(`/api/courses/grades/${gradeId}`)
+        .set('Authorization', `Bearer ${teacherToken}`)
+        .send({
+          type: 'current',
+          value: 88,
+          comment: 'Updated after review',
+        })
+        .expect(200);
+
+      const updatedSubmission = await connection
+        .collection('submissions')
+        .findOne({ _id: submissionId });
+      expect(updatedSubmission?.status).toBe('graded');
+      expect(updatedSubmission?.score).toBe(88);
+      expect(updatedSubmission?.comment).toBe('Updated after review');
+
+      const studentAssignmentsResponse = await request(app.getHttpServer())
+        .get('/api/courses/assignments/my')
+        .set('Authorization', `Bearer ${studentToken}`)
+        .expect(200);
+
+      const studentAssignmentsBody =
+        studentAssignmentsResponse.body as PaginatedDto<AssignmentDto>;
+      const studentAssignment = studentAssignmentsBody.docs.find(
+        (assignment) => assignment.id === assignmentId.toHexString(),
+      );
+      expect(studentAssignment?.submission?.status).toBe('graded');
+      expect(studentAssignment?.submission?.score).toBe(88);
+      expect(studentAssignment?.submission?.comment).toBe(
+        'Updated after review',
+      );
+
+      const updatedGradeNotifications = await connection
+        .collection('notifications')
+        .countDocuments({
+          userId: studentId,
+          type: 'grade',
+          entityType: 'grade',
+          entityId: gradeId,
+        });
+      expect(updatedGradeNotifications).toBe(2);
 
       const gradesResponse = await request(app.getHttpServer())
         .get(
@@ -596,7 +699,7 @@ describe('Assignments (e2e)', () => {
         expect.arrayContaining([
           expect.objectContaining({
             assignmentTitle: 'To Grade',
-            value: 95,
+            value: 88,
           }),
         ]),
       );
@@ -637,6 +740,72 @@ describe('Assignments (e2e)', () => {
         .send({
           score: 70,
           comment: 'Too high',
+        })
+        .expect(400);
+    });
+
+    it('should reject editing an already graded submission after deadline (400)', async () => {
+      const { courseAssignmentId, teacherToken, studentId, groupId } =
+        await setupAssignments();
+      const assignmentId = new Types.ObjectId();
+      const submissionId = new Types.ObjectId();
+
+      await connection.collection('assignments').insertOne({
+        _id: assignmentId,
+        courseAssignment: courseAssignmentId,
+        group: groupId,
+        title: 'Locked Grade',
+        description: 'Desc',
+        dueDate: new Date(Date.now() - 86400000),
+        maxScore: 100,
+        files: [],
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      await connection.collection('submissions').insertOne({
+        _id: submissionId,
+        assignment: assignmentId,
+        student: studentId,
+        files: [],
+        status: 'graded',
+        score: 80,
+        comment: 'Initial grade',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      const gradeId = new Types.ObjectId();
+      await connection.collection('grades').insertOne({
+        _id: gradeId,
+        student: studentId,
+        courseAssignment: courseAssignmentId,
+        assignment: assignmentId,
+        submission: submissionId,
+        type: 'current',
+        value: 80,
+        comment: 'Initial grade',
+        date: new Date(Date.now() - 3600000),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      await request(app.getHttpServer())
+        .post(`/api/courses/submissions/${submissionId.toHexString()}/grade`)
+        .set('Authorization', `Bearer ${teacherToken}`)
+        .send({
+          score: 90,
+          comment: 'Late edit',
+        })
+        .expect(400);
+
+      await request(app.getHttpServer())
+        .patch(`/api/courses/grades/${gradeId.toHexString()}`)
+        .set('Authorization', `Bearer ${teacherToken}`)
+        .send({
+          type: 'current',
+          value: 90,
+          comment: 'Late journal edit',
         })
         .expect(400);
     });


### PR DESCRIPTION
## Summary
- Hardened assignment submission and grading workflows for teachers and students.
- Synced edited assignment grades with linked submissions so students immediately see updated scores and feedback.
- Added student notifications when teachers change assignment grades before the deadline.
- Routed assignment-related notifications to the exact course tab or student assignments page.
- Kept teacher review queues focused on ungraded submitted work.
- Polished student assignment cards by removing duplicated grade display.

## Backend
- Prevents grade edits after assignment deadlines.
- Validates edited grades against assignment max score.
- Keeps `Grade` and `Submission` records consistent when linked assignment grades are edited.
- Resets linked submissions back to `submitted` if a grade is deleted before the deadline.
- Adds MongoDB e2e coverage for grade edit synchronization, student visibility and notifications.

## Frontend
- Supports notification deep links to course assignment/submission tabs.
- Keeps student assignment grade display clean and non-duplicated.

## Checks
- server `npm run lint:check`
- server `npm run build`
- server `npm test -- --runInBand`
- server `npm run test:e2e`
- server `npm run test:e2e:db -- assignments.e2e-spec.ts --runInBand`
- client `npm run lint`
- client `npm run build`
- server `npm audit --audit-level=moderate`
- client `npm audit --audit-level=moderate`
- `git diff --check`

##

Closed #28 
Closed #30 
Closed #31 
Closed #32 
Closed #33 
Closed #34 
Closed #35 