### PR TITLE
fix(test): remove misleading audit errors from electives E2E output

### DIFF
--- a/server/src/audit-log/audit-log.service.spec.ts
+++ b/server/src/audit-log/audit-log.service.spec.ts
@@ -9,6 +9,7 @@ describe('AuditLogService', () => {
   let service: AuditLogService;
   let loggerErrorSpy: jest.SpyInstance;
   let loggerLogSpy: jest.SpyInstance;
+  let loggerWarnSpy: jest.SpyInstance;
   const auditModel = {
     create: jest.fn().mockResolvedValue({}),
     find: jest.fn(),
@@ -19,6 +20,7 @@ describe('AuditLogService', () => {
     jest.clearAllMocks();
     loggerErrorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation();
     loggerLogSpy = jest.spyOn(Logger.prototype, 'log').mockImplementation();
+    loggerWarnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -36,6 +38,7 @@ describe('AuditLogService', () => {
   afterEach(() => {
     loggerErrorSpy.mockRestore();
     loggerLogSpy.mockRestore();
+    loggerWarnSpy.mockRestore();
   });
 
   it('should be defined', () => {
@@ -63,6 +66,10 @@ describe('AuditLogService', () => {
         requestId: 'req-1',
       }),
     );
+    expect(loggerWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Result: failure'),
+    );
+    expect(loggerErrorSpy).not.toHaveBeenCalled();
   });
 
   it('should redact sensitive audit details before persisting', async () => {

--- a/server/src/audit-log/audit-log.service.ts
+++ b/server/src/audit-log/audit-log.service.ts
@@ -167,7 +167,7 @@ export class AuditLogService {
     if (entry.result === 'success') {
       this.logger.log(logMessage);
     } else {
-      this.logger.error(logMessage);
+      this.logger.warn(logMessage);
     }
 
     void this.auditModel

--- a/server/test/electives.e2e-spec.ts
+++ b/server/test/electives.e2e-spec.ts
@@ -104,6 +104,7 @@ describe('Elective disciplines (e2e)', () => {
       .compile();
 
     app = moduleFixture.createNestApplication<NestExpressApplication>();
+    app.useLogger(['error']);
     configureApp(app, { swaggerEnabled: false });
     await app.init();
 


### PR DESCRIPTION
Log expected rejected security actions as warnings while preserving error severity for audit persistence and infrastructure failures.

Keep ElectiveDisciplines E2E output focused on genuine errors without disabling audit failure persistence checks.