### PR TITLE
feat(surveys): enforce period lifecycle and add secure XLSX/CSV exports (Resolves #22, #27)

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,10 +298,11 @@ interface Survey {
   targetIds: string[]; // group ids для groups, course/course assignment ids для course, порожній масив для all/teachers/students_teachers
   status: "draft" | "active" | "closed";
   anonymous: boolean; // якщо true — відповіді без userId
-  startDate?: string;
-  endDate?: string;
+  startDate: string;
+  endDate: string;
   publishedAt?: string;
   closedAt?: string;
+  expectedRecipients?: number; // знімок розміру аудиторії на момент публікації
   createdAt: string;
   updatedAt: string;
 }
@@ -343,17 +344,23 @@ interface SurveyResponse {
 | POST   | `/surveys/:id/respond`        | student, teacher                | Надіслати відповіді                          |
 | GET    | `/surveys/:id/my-response`    | student, teacher                | Перевірити — чи вже пройшов                  |
 | GET    | `/surveys/:id/results`        | admin, dean (автор), rector, president | Агреговані результати                 |
-| GET    | `/surveys/:id/results/export` | admin, dean (автор), rector, president | Вивантаження у CSV                    |
+| GET    | `/surveys/:id/results/export?format=csv` | admin, dean (автор), rector, president | Структурований UTF-8 CSV-звіт після закриття |
+| GET    | `/surveys/:id/results/export?format=xlsx` | admin, dean (автор), rector, president | Форматований XLSX-звіт після закриття |
 
 **Логіка:**
 
 - Студент або викладач може проходити доступне йому опитування **лише один раз**
+- Дата початку та дата завершення є обов’язковими; без повного коректного періоду чернетку не можна створити або опублікувати
 - Аудиторія `all` означає всіх студентів; для викладачів використовуються окремі аудиторії `teachers` і `students_teachers`
 - При `isAnonymous: true` — userId не зберігається у відповіді, але факт проходження фіксується окремо (щоб не дати пройти двічі)
 - Публікація з майбутнім `startDate` зберігає запланований старт; опитування видиме за прямим посиланням, але пройти його можна лише після старту
 - Опитування з `endDate` у минулому автоматично переводяться в статус `closed` під час запитів
+- Під час публікації фіксується кількість активних отримувачів; історичний відсоток проходження не змінюється через подальші зміни груп, курсів або статусів користувачів
+- Живі агреговані результати доступні для активного опитування, але фінальний XLSX/CSV-експорт дозволений лише після переходу в статус `closed`
 - Результати показують: очікувану аудиторію, кількість проходжень, відсоток проходження, кількість відповідей на кожен варіант, середнє для rating, текстові відповіді списком
-- CSV-експорт екранує формули (`=`, `+`, `-`, `@`) для захисту від spreadsheet injection
+- CSV використовує UTF-8 BOM, Excel-сумісний роздільник `;`, CRLF та українські заголовки
+- XLSX містить окремі аркуші зведення, розподілу відповідей і текстових відповідей, автофільтри, закріплені рядки та числові формати
+- XLSX/CSV-експорт екранує формули (`=`, `+`, `-`, `@`) для захисту від spreadsheet injection та повертається з `Cache-Control: private, no-store`
 - Для модуля є окремий MongoDB E2E quality gate: `npm run test:e2e:db -- surveys.e2e-spec.ts`
 
 ---
@@ -651,7 +658,8 @@ src/
   - single/multiple_choice: горизонтальна гістограма з кількістю та відсотком
   - rating: середнє значення + розподіл
   - text: список відповідей із пагінацією
-- Кнопка "Вивантажити CSV"
+- Для активного опитування показуються живі результати без кнопок експорту
+- Після закриття доступні кнопки "Експорт CSV" і "Експорт XLSX"
 
 ---
 
@@ -826,7 +834,8 @@ AuditLogEntry
 | POST   | `/surveys/:id/respond`        | student, teacher                |
 | GET    | `/surveys/:id/my-response`    | student, teacher                |
 | GET    | `/surveys/:id/results`        | admin, dean (автор), rector, president |
-| GET    | `/surveys/:id/results/export` | admin, dean (автор), rector, president |
+| GET    | `/surveys/:id/results/export?format=csv` | admin, dean (автор), rector, president |
+| GET    | `/surveys/:id/results/export?format=xlsx` | admin, dean (автор), rector, president |
 
 ### Сповіщення `/api/notifications`
 

--- a/client/src/i18n.ts
+++ b/client/src/i18n.ts
@@ -596,6 +596,8 @@ const resources = {
       'surveys.admin.validation.titleRequired': 'Вкажіть назву опитування',
       'surveys.admin.validation.targetRequired':
         'Для вибраної аудиторії потрібно вказати ідентифікатори',
+      'surveys.admin.validation.datesRequired':
+        'Вкажіть дату початку та дату завершення опитування',
       'surveys.admin.validation.endAfterStart':
         'Дата завершення має бути пізніше дати початку',
       'surveys.admin.validation.questionInvalid':
@@ -604,8 +606,11 @@ const resources = {
       'surveys.results.title': 'Результати опитування',
       'surveys.results.loadError': 'Не вдалося завантажити результати',
       'surveys.results.exportCsv': 'Експорт CSV',
+      'surveys.results.exportXlsx': 'Експорт XLSX',
       'surveys.results.exporting': 'Експорт...',
-      'surveys.results.exportError': 'Не вдалося експортувати CSV',
+      'surveys.results.exportError': 'Не вдалося експортувати результати',
+      'surveys.results.liveNotice':
+        'Показано поточні результати активного опитування. Експорт CSV/XLSX стане доступним після закриття опитування.',
       'surveys.results.expectedRecipients': 'Цільова аудиторія',
       'surveys.results.totalCompletions': 'Проходжень',
       'surveys.results.totalResponses': 'Збережених відповідей',
@@ -1281,6 +1286,8 @@ const resources = {
       'surveys.admin.validation.titleRequired': 'Enter survey title',
       'surveys.admin.validation.targetRequired':
         'Audience identifiers are required for the selected target type',
+      'surveys.admin.validation.datesRequired':
+        'Enter both the survey start date and end date',
       'surveys.admin.validation.endAfterStart':
         'End date must be later than start date',
       'surveys.admin.validation.questionInvalid':
@@ -1289,8 +1296,11 @@ const resources = {
       'surveys.results.title': 'Survey results',
       'surveys.results.loadError': 'Could not load results',
       'surveys.results.exportCsv': 'Export CSV',
+      'surveys.results.exportXlsx': 'Export XLSX',
       'surveys.results.exporting': 'Exporting...',
-      'surveys.results.exportError': 'Could not export CSV',
+      'surveys.results.exportError': 'Could not export survey results',
+      'surveys.results.liveNotice':
+        'These are live results for an active survey. CSV/XLSX export becomes available after the survey is closed.',
       'surveys.results.expectedRecipients': 'Target audience',
       'surveys.results.totalCompletions': 'Completions',
       'surveys.results.totalResponses': 'Saved responses',

--- a/client/src/pages/surveys/SurveyAdminPage.tsx
+++ b/client/src/pages/surveys/SurveyAdminPage.tsx
@@ -86,10 +86,8 @@ function surveyTargetTypeRequiresIds(targetType: SurveyTargetType) {
 }
 
 function toIsoDateTime(value: string) {
-  if (!value) return undefined;
-
   const date = new Date(value);
-  return Number.isNaN(date.getTime()) ? undefined : date.toISOString();
+  return Number.isNaN(date.getTime()) ? value : date.toISOString();
 }
 
 function toDateTimeLocalValue(value?: string) {
@@ -194,12 +192,14 @@ function validateSurveyForm(form: SurveyFormState, t: (key: string) => string) {
     return t('surveys.admin.validation.targetRequired');
   }
 
-  if (form.startDate && form.endDate) {
-    const start = new Date(form.startDate).getTime();
-    const end = new Date(form.endDate).getTime();
-    if (!Number.isNaN(start) && !Number.isNaN(end) && end <= start) {
-      return t('surveys.admin.validation.endAfterStart');
-    }
+  if (!form.startDate || !form.endDate) {
+    return t('surveys.admin.validation.datesRequired');
+  }
+
+  const start = new Date(form.startDate).getTime();
+  const end = new Date(form.endDate).getTime();
+  if (!Number.isNaN(start) && !Number.isNaN(end) && end <= start) {
+    return t('surveys.admin.validation.endAfterStart');
   }
 
   const invalidQuestion = form.questions.find((question) => {
@@ -320,13 +320,15 @@ function SurveyManagementRow({
         </div>
 
         <div className="flex flex-wrap gap-2 lg:justify-end">
-          <Link
-            to={`/surveys/admin/${survey.id}/results`}
-            className="inline-flex min-h-9 items-center justify-center gap-2 rounded-lg border border-slate-300 px-3 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-50"
-          >
-            <BarChart3 className="h-4 w-4" aria-hidden="true" />
-            {t('surveys.admin.results')}
-          </Link>
+          {survey.status !== SurveyStatus.DRAFT && (
+            <Link
+              to={`/surveys/admin/${survey.id}/results`}
+              className="inline-flex min-h-9 items-center justify-center gap-2 rounded-lg border border-slate-300 px-3 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-50"
+            >
+              <BarChart3 className="h-4 w-4" aria-hidden="true" />
+              {t('surveys.admin.results')}
+            </Link>
+          )}
 
           {survey.status === SurveyStatus.DRAFT && (
             <button
@@ -889,9 +891,12 @@ export default function SurveyAdminPage() {
 
             <div className="grid gap-3 sm:grid-cols-2">
               <label className="space-y-1 text-sm text-slate-600">
-                <span>{t('surveys.startsAt')}</span>
+                <span>
+                  {t('surveys.startsAt')} <span className="text-red-600">*</span>
+                </span>
                 <input
                   type="datetime-local"
+                  required
                   value={form.startDate}
                   onChange={(event) =>
                     setForm((current) => ({
@@ -904,9 +909,12 @@ export default function SurveyAdminPage() {
               </label>
 
               <label className="space-y-1 text-sm text-slate-600">
-                <span>{t('surveys.endsAt')}</span>
+                <span>
+                  {t('surveys.endsAt')} <span className="text-red-600">*</span>
+                </span>
                 <input
                   type="datetime-local"
+                  required
                   value={form.endDate}
                   onChange={(event) =>
                     setForm((current) => ({

--- a/client/src/pages/surveys/SurveyResultsPage.tsx
+++ b/client/src/pages/surveys/SurveyResultsPage.tsx
@@ -7,14 +7,19 @@ import {
   ArrowLeft,
   BarChart3,
   Download,
+  FileSpreadsheet,
   FileText,
   ShieldCheck,
   Star,
   Users,
 } from 'lucide-react';
-import { surveysApi } from '../../services/surveysApi';
+import {
+  surveysApi,
+  type SurveyExportFormat,
+} from '../../services/surveysApi';
 import {
   SurveyQuestionType,
+  SurveyStatus,
   type ChoiceQuestionResult,
   type RatingQuestionResult,
   type SurveyQuestionResult,
@@ -241,7 +246,8 @@ export default function SurveyResultsPage() {
   const { id } = useParams<{ id: string }>();
   const { t } = useTranslation();
   const [exportError, setExportError] = useState('');
-  const [isExporting, setIsExporting] = useState(false);
+  const [exportingFormat, setExportingFormat] =
+    useState<SurveyExportFormat | null>(null);
 
   const {
     data: results,
@@ -251,24 +257,25 @@ export default function SurveyResultsPage() {
     queryKey: ['surveys', id, 'results'],
     enabled: Boolean(id),
     queryFn: () => surveysApi.getResults(id as string),
-    refetchInterval: 30_000,
+    refetchInterval: (query) =>
+      query.state.data?.survey.status === SurveyStatus.ACTIVE ? 30_000 : false,
   });
 
-  const handleExport = async () => {
+  const handleExport = async (format: SurveyExportFormat) => {
     if (!id) return;
 
-    setIsExporting(true);
+    setExportingFormat(format);
     setExportError('');
 
     try {
-      const blob = await surveysApi.exportResultsCsv(id);
-      downloadBlob(blob, `survey-${id}-results.csv`);
+      const blob = await surveysApi.exportResults(id, format);
+      downloadBlob(blob, `survey-${id}-results.${format}`);
     } catch (error) {
       setExportError(
         getRequestErrorMessage(error, t('surveys.results.exportError')),
       );
     } finally {
-      setIsExporting(false);
+      setExportingFormat(null);
     }
   };
 
@@ -297,6 +304,8 @@ export default function SurveyResultsPage() {
     );
   }
 
+  const canExport = results.survey.status === SurveyStatus.CLOSED;
+
   return (
     <div className="space-y-6">
       <Link
@@ -314,6 +323,15 @@ export default function SurveyResultsPage() {
               <span className="inline-flex items-center gap-1 rounded-md bg-blue-50 px-2.5 py-1 text-xs font-semibold text-blue-700">
                 <BarChart3 className="h-3.5 w-3.5" aria-hidden="true" />
                 {t('surveys.results.title')}
+              </span>
+              <span
+                className={`rounded-md px-2.5 py-1 text-xs font-semibold ${
+                  canExport
+                    ? 'bg-slate-100 text-slate-700'
+                    : 'bg-emerald-50 text-emerald-700'
+                }`}
+              >
+                {t(`surveys.statuses.${results.survey.status}`)}
               </span>
               {results.anonymous && (
                 <span className="inline-flex items-center gap-1 rounded-md bg-slate-100 px-2.5 py-1 text-xs font-semibold text-slate-700">
@@ -334,18 +352,39 @@ export default function SurveyResultsPage() {
             )}
           </div>
 
-          <button
-            type="button"
-            onClick={handleExport}
-            disabled={isExporting}
-            className="inline-flex min-h-11 shrink-0 items-center justify-center gap-2 rounded-lg bg-blue-600 px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-300"
-          >
-            <Download className="h-4 w-4" aria-hidden="true" />
-            {isExporting
-              ? t('surveys.results.exporting')
-              : t('surveys.results.exportCsv')}
-          </button>
+          {canExport && (
+            <div className="flex flex-wrap gap-2">
+              <button
+                type="button"
+                onClick={() => handleExport('csv')}
+                disabled={exportingFormat !== null}
+                className="inline-flex min-h-11 shrink-0 items-center justify-center gap-2 rounded-lg border border-slate-300 bg-white px-4 py-2.5 text-sm font-semibold text-slate-700 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:text-slate-300"
+              >
+                <Download className="h-4 w-4" aria-hidden="true" />
+                {exportingFormat === 'csv'
+                  ? t('surveys.results.exporting')
+                  : t('surveys.results.exportCsv')}
+              </button>
+              <button
+                type="button"
+                onClick={() => handleExport('xlsx')}
+                disabled={exportingFormat !== null}
+                className="inline-flex min-h-11 shrink-0 items-center justify-center gap-2 rounded-lg bg-blue-600 px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-300"
+              >
+                <FileSpreadsheet className="h-4 w-4" aria-hidden="true" />
+                {exportingFormat === 'xlsx'
+                  ? t('surveys.results.exporting')
+                  : t('surveys.results.exportXlsx')}
+              </button>
+            </div>
+          )}
         </div>
+
+        {!canExport && (
+          <div className="mt-5 rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-800">
+            {t('surveys.results.liveNotice')}
+          </div>
+        )}
 
         <div className="mt-5 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
           <div className="rounded-lg bg-slate-50 px-4 py-3">

--- a/client/src/services/surveysApi.ts
+++ b/client/src/services/surveysApi.ts
@@ -23,6 +23,8 @@ export type SurveyListFilters = {
   targetType?: SurveyTargetType | '';
 };
 
+export type SurveyExportFormat = 'csv' | 'xlsx';
+
 function buildSurveyParams(filters?: SurveyListFilters) {
   const params = new URLSearchParams();
 
@@ -106,11 +108,19 @@ export const surveysApi = {
     return data;
   },
 
-  exportResultsCsv: async (id: string) => {
-    const { data } = await api.get<Blob>(`/surveys/${id}/results/export`, {
-      responseType: 'blob',
-    });
-    return data;
+  exportResults: async (id: string, format: SurveyExportFormat) => {
+    const { data } = await api.get<ArrayBuffer>(
+      `/surveys/${id}/results/export`,
+      {
+        params: { format },
+        responseType: 'arraybuffer',
+      },
+    );
+    const contentType =
+      format === 'xlsx'
+        ? 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+        : 'text/csv;charset=utf-8';
+    return new Blob([data], { type: contentType });
   },
 
   listTargetGroups: async () => {

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -323,10 +323,11 @@ export interface Survey {
   targetType: SurveyTargetType;
   targetIds: string[];
   createdBy: string;
-  startDate?: string;
-  endDate?: string;
+  startDate: string;
+  endDate: string;
   publishedAt?: string;
   closedAt?: string;
+  expectedRecipients?: number;
   createdAt?: string;
   updatedAt?: string;
   completed?: boolean;
@@ -365,8 +366,8 @@ export interface CreateSurveyInput {
   anonymous?: boolean;
   targetType?: SurveyTargetType;
   targetIds?: string[];
-  startDate?: string;
-  endDate?: string;
+  startDate: string;
+  endDate: string;
   questions: CreateSurveyQuestionInput[];
 }
 

--- a/server/src/surveys/dto/create-survey.dto.ts
+++ b/server/src/surveys/dto/create-survey.dto.ts
@@ -82,15 +82,13 @@ export class CreateSurveyDto {
   @MaxLength(80, { each: true })
   targetIds?: string[];
 
-  @ApiPropertyOptional({ format: 'date-time' })
-  @IsOptional()
+  @ApiProperty({ format: 'date-time' })
   @IsISO8601()
-  startDate?: string;
+  startDate: string;
 
-  @ApiPropertyOptional({ format: 'date-time' })
-  @IsOptional()
+  @ApiProperty({ format: 'date-time' })
   @IsISO8601()
-  endDate?: string;
+  endDate: string;
 
   @ApiProperty({ type: [CreateSurveyQuestionDto], minItems: 1, maxItems: 100 })
   @IsArray()

--- a/server/src/surveys/dto/survey-export-query.dto.ts
+++ b/server/src/surveys/dto/survey-export-query.dto.ts
@@ -1,0 +1,17 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsEnum, IsOptional } from 'class-validator';
+
+export enum SurveyExportFormat {
+  CSV = 'csv',
+  XLSX = 'xlsx',
+}
+
+export class SurveyExportQueryDto {
+  @ApiPropertyOptional({
+    enum: SurveyExportFormat,
+    default: SurveyExportFormat.CSV,
+  })
+  @IsOptional()
+  @IsEnum(SurveyExportFormat)
+  format: SurveyExportFormat = SurveyExportFormat.CSV;
+}

--- a/server/src/surveys/schemas/survey.schema.ts
+++ b/server/src/surveys/schemas/survey.schema.ts
@@ -38,17 +38,20 @@ export class Survey {
   @Prop({ type: Types.ObjectId, ref: User.name, required: true, index: true })
   createdBy: Types.ObjectId;
 
-  @Prop({ type: Date })
-  startDate?: Date;
+  @Prop({ type: Date, required: true })
+  startDate: Date;
 
-  @Prop({ type: Date, index: true })
-  endDate?: Date;
+  @Prop({ type: Date, required: true, index: true })
+  endDate: Date;
 
   @Prop({ type: Date })
   publishedAt?: Date;
 
   @Prop({ type: Date })
   closedAt?: Date;
+
+  @Prop({ type: Number, min: 0 })
+  expectedRecipients?: number;
 
   createdAt: Date;
   updatedAt: Date;

--- a/server/src/surveys/survey-results-exporter.ts
+++ b/server/src/surveys/survey-results-exporter.ts
@@ -1,0 +1,574 @@
+import * as ExcelJS from 'exceljs';
+import { SurveyQuestionType, SurveyStatus, SurveyTargetType } from './schemas';
+
+type ExportSurvey = {
+  title: string;
+  description?: string;
+  status: SurveyStatus;
+  anonymous: boolean;
+  targetType: SurveyTargetType;
+  startDate?: string;
+  endDate?: string;
+  publishedAt?: string;
+  closedAt?: string;
+};
+
+type ChoiceQuestion = {
+  type: SurveyQuestionType.SINGLE | SurveyQuestionType.MULTIPLE;
+  text: string;
+  required: boolean;
+  order: number;
+  totalAnswers: number;
+  options: Array<{
+    value: string;
+    count: number;
+    percentage: number;
+  }>;
+};
+
+type RatingQuestion = {
+  type: SurveyQuestionType.RATING;
+  text: string;
+  required: boolean;
+  order: number;
+  totalAnswers: number;
+  average: number | null;
+  min: number | null;
+  max: number | null;
+  distribution: Array<{
+    rating: number;
+    count: number;
+    percentage: number;
+  }>;
+};
+
+type TextQuestion = {
+  type: SurveyQuestionType.TEXT;
+  text: string;
+  required: boolean;
+  order: number;
+  totalAnswers: number;
+  answers: string[];
+};
+
+type ExportQuestion = ChoiceQuestion | RatingQuestion | TextQuestion;
+
+export type SurveyExportResults = {
+  survey: ExportSurvey;
+  anonymous: boolean;
+  totalResponses: number;
+  totalCompletions: number;
+  expectedRecipients: number;
+  completionRate: number;
+  questions: ExportQuestion[];
+};
+
+const HEADER_FILL = '1D4ED8';
+const SUBHEADER_FILL = 'DBEAFE';
+const BORDER_COLOR = 'CBD5E1';
+
+export function buildSurveyResultsCsv(results: SurveyExportResults): string {
+  const rows: string[][] = [
+    [
+      'Опитування',
+      'Статус',
+      'Анонімне',
+      'Цільова аудиторія',
+      'Початок',
+      'Завершення',
+      'Очікувано отримувачів',
+      'Проходжень',
+      'Збережених відповідей',
+      'Виконання, %',
+      '№ питання',
+      'Тип питання',
+      'Питання',
+      'Обов’язкове',
+      'Метрика',
+      'Значення',
+      'Кількість',
+      'Відповідей на питання',
+      'Відсоток, %',
+      'Середнє',
+      'Мінімум',
+      'Максимум',
+    ],
+  ];
+
+  for (const question of results.questions) {
+    const commonColumns = buildCsvCommonColumns(results, question);
+
+    if (
+      question.type === SurveyQuestionType.SINGLE ||
+      question.type === SurveyQuestionType.MULTIPLE
+    ) {
+      for (const option of question.options) {
+        rows.push([
+          ...commonColumns,
+          'Варіант відповіді',
+          option.value,
+          String(option.count),
+          String(question.totalAnswers),
+          formatNumber(option.percentage),
+          '',
+          '',
+          '',
+        ]);
+      }
+      continue;
+    }
+
+    if (question.type === SurveyQuestionType.RATING) {
+      for (const item of question.distribution) {
+        rows.push([
+          ...commonColumns,
+          'Оцінка',
+          String(item.rating),
+          String(item.count),
+          String(question.totalAnswers),
+          formatNumber(item.percentage),
+          question.average === null ? '' : formatNumber(question.average),
+          question.min === null ? '' : String(question.min),
+          question.max === null ? '' : String(question.max),
+        ]);
+      }
+      continue;
+    }
+
+    if (question.type !== SurveyQuestionType.TEXT) continue;
+
+    if (question.answers.length === 0) {
+      rows.push([
+        ...commonColumns,
+        'Текстова відповідь',
+        '',
+        '0',
+        String(question.totalAnswers),
+        '',
+        '',
+        '',
+        '',
+      ]);
+      continue;
+    }
+
+    for (const answer of question.answers) {
+      rows.push([
+        ...commonColumns,
+        'Текстова відповідь',
+        answer,
+        '1',
+        String(question.totalAnswers),
+        '',
+        '',
+        '',
+        '',
+      ]);
+    }
+  }
+
+  const body = rows
+    .map((row) => row.map((value) => escapeCsvCell(value)).join(';'))
+    .join('\r\n');
+
+  return `\uFEFF${body}\r\n`;
+}
+
+export async function buildSurveyResultsXlsx(
+  results: SurveyExportResults,
+): Promise<Buffer> {
+  const workbook = new ExcelJS.Workbook();
+  workbook.creator = 'MAUP Online Campus';
+  workbook.lastModifiedBy = 'MAUP Online Campus';
+  workbook.created = new Date();
+  workbook.modified = new Date();
+  workbook.calcProperties.fullCalcOnLoad = true;
+
+  addSummaryWorksheet(workbook, results);
+  addDistributionWorksheet(workbook, results);
+  addTextAnswersWorksheet(workbook, results);
+
+  const buffer = await workbook.xlsx.writeBuffer();
+  return Buffer.from(buffer);
+}
+
+function buildCsvCommonColumns(
+  results: SurveyExportResults,
+  question: ExportQuestion,
+): string[] {
+  return [
+    results.survey.title,
+    surveyStatusLabel(results.survey.status),
+    results.anonymous ? 'Так' : 'Ні',
+    surveyTargetLabel(results.survey.targetType),
+    formatDateTime(results.survey.startDate),
+    formatDateTime(results.survey.endDate),
+    String(results.expectedRecipients),
+    String(results.totalCompletions),
+    String(results.totalResponses),
+    formatNumber(results.completionRate),
+    String(question.order + 1),
+    questionTypeLabel(question.type),
+    question.text,
+    question.required ? 'Так' : 'Ні',
+  ];
+}
+
+function addSummaryWorksheet(
+  workbook: ExcelJS.Workbook,
+  results: SurveyExportResults,
+): void {
+  const sheet = workbook.addWorksheet('Зведення', {
+    views: [{ state: 'frozen', ySplit: 17 }],
+    properties: { defaultRowHeight: 20 },
+    pageSetup: {
+      orientation: 'landscape',
+      fitToPage: true,
+      fitToWidth: 1,
+      fitToHeight: 0,
+    },
+  });
+
+  sheet.mergeCells('A1:H1');
+  const title = sheet.getCell('A1');
+  title.value = 'Результати опитування';
+  title.font = { bold: true, color: { argb: 'FFFFFFFF' }, size: 16 };
+  title.fill = solidFill(HEADER_FILL);
+  title.alignment = { vertical: 'middle', horizontal: 'center' };
+  sheet.getRow(1).height = 32;
+
+  const metadata: Array<[string, string | number]> = [
+    ['Назва', results.survey.title],
+    ['Опис', results.survey.description ?? ''],
+    ['Статус', surveyStatusLabel(results.survey.status)],
+    ['Анонімне', results.anonymous ? 'Так' : 'Ні'],
+    ['Цільова аудиторія', surveyTargetLabel(results.survey.targetType)],
+    ['Початок', formatDateTime(results.survey.startDate)],
+    ['Завершення', formatDateTime(results.survey.endDate)],
+    ['Очікувано отримувачів', results.expectedRecipients],
+    ['Проходжень', results.totalCompletions],
+    ['Збережених відповідей', results.totalResponses],
+    ['Виконання', results.completionRate / 100],
+  ];
+
+  metadata.forEach(([label, value], index) => {
+    const row = sheet.getRow(index + 3);
+    row.getCell(1).value = label;
+    row.getCell(1).font = { bold: true, color: { argb: 'FF1E3A8A' } };
+    row.getCell(1).fill = solidFill('EFF6FF');
+    row.getCell(2).value = sanitizeSpreadsheetText(value);
+    sheet.mergeCells(index + 3, 2, index + 3, 8);
+    row.getCell(2).alignment = {
+      vertical: 'middle',
+      horizontal: 'left',
+      wrapText: true,
+    };
+  });
+  sheet.getCell('B13').numFmt = '0.00%';
+
+  const headerRowNumber = 17;
+  const headerRow = sheet.getRow(headerRowNumber);
+  headerRow.values = [
+    '№',
+    'Тип',
+    'Питання',
+    'Обов’язкове',
+    'Відповідей',
+    'Середнє',
+    'Мінімум',
+    'Максимум',
+  ];
+  styleHeaderRow(headerRow);
+
+  for (const question of results.questions) {
+    const row = sheet.addRow([
+      question.order + 1,
+      questionTypeLabel(question.type),
+      sanitizeSpreadsheetText(question.text),
+      question.required ? 'Так' : 'Ні',
+      question.totalAnswers,
+      question.type === SurveyQuestionType.RATING
+        ? (question.average ?? '')
+        : '',
+      question.type === SurveyQuestionType.RATING ? (question.min ?? '') : '',
+      question.type === SurveyQuestionType.RATING ? (question.max ?? '') : '',
+    ]);
+    styleDataRow(row);
+    alignCellsLeft(row, 2, 4);
+  }
+
+  sheet.autoFilter = {
+    from: { row: headerRowNumber, column: 1 },
+    to: { row: headerRowNumber, column: 8 },
+  };
+  sheet.columns = [
+    { width: 38 },
+    { width: 22 },
+    { width: 54 },
+    { width: 16 },
+    { width: 14 },
+    { width: 14 },
+    { width: 12 },
+    { width: 12 },
+  ];
+}
+
+function addDistributionWorksheet(
+  workbook: ExcelJS.Workbook,
+  results: SurveyExportResults,
+): void {
+  const sheet = workbook.addWorksheet('Розподіл відповідей', {
+    views: [{ state: 'frozen', ySplit: 2 }],
+    properties: { defaultRowHeight: 20 },
+    pageSetup: {
+      orientation: 'landscape',
+      fitToPage: true,
+      fitToWidth: 1,
+      fitToHeight: 0,
+    },
+  });
+
+  sheet.mergeCells('A1:H1');
+  const title = sheet.getCell('A1');
+  title.value = sanitizeSpreadsheetText(results.survey.title);
+  title.font = { bold: true, color: { argb: 'FFFFFFFF' }, size: 14 };
+  title.fill = solidFill(HEADER_FILL);
+  title.alignment = { vertical: 'middle', horizontal: 'center' };
+  sheet.getRow(1).height = 28;
+
+  const headerRow = sheet.getRow(2);
+  headerRow.values = [
+    '№ питання',
+    'Тип',
+    'Питання',
+    'Метрика',
+    'Значення',
+    'Кількість',
+    'Відповідей',
+    'Відсоток',
+  ];
+  styleHeaderRow(headerRow);
+
+  for (const question of results.questions) {
+    if (
+      question.type === SurveyQuestionType.SINGLE ||
+      question.type === SurveyQuestionType.MULTIPLE
+    ) {
+      for (const option of question.options) {
+        const row = sheet.addRow([
+          question.order + 1,
+          questionTypeLabel(question.type),
+          sanitizeSpreadsheetText(question.text),
+          'Варіант відповіді',
+          sanitizeSpreadsheetText(option.value),
+          option.count,
+          question.totalAnswers,
+          option.percentage / 100,
+        ]);
+        row.getCell(8).numFmt = '0.00%';
+        styleDataRow(row);
+        alignCellsLeft(row, 2, 5);
+      }
+      continue;
+    }
+
+    if (question.type === SurveyQuestionType.RATING) {
+      for (const item of question.distribution) {
+        const row = sheet.addRow([
+          question.order + 1,
+          questionTypeLabel(question.type),
+          sanitizeSpreadsheetText(question.text),
+          'Оцінка',
+          item.rating,
+          item.count,
+          question.totalAnswers,
+          item.percentage / 100,
+        ]);
+        row.getCell(8).numFmt = '0.00%';
+        styleDataRow(row);
+        alignCellsLeft(row, 2, 4);
+      }
+    }
+  }
+
+  sheet.autoFilter = {
+    from: { row: 2, column: 1 },
+    to: { row: 2, column: 8 },
+  };
+  sheet.columns = [
+    { width: 12 },
+    { width: 22 },
+    { width: 54 },
+    { width: 22 },
+    { width: 34 },
+    { width: 14 },
+    { width: 14 },
+    { width: 14 },
+  ];
+}
+
+function addTextAnswersWorksheet(
+  workbook: ExcelJS.Workbook,
+  results: SurveyExportResults,
+): void {
+  const sheet = workbook.addWorksheet('Текстові відповіді', {
+    views: [{ state: 'frozen', ySplit: 2 }],
+    properties: { defaultRowHeight: 20 },
+    pageSetup: {
+      orientation: 'landscape',
+      fitToPage: true,
+      fitToWidth: 1,
+      fitToHeight: 0,
+    },
+  });
+
+  sheet.mergeCells('A1:D1');
+  const title = sheet.getCell('A1');
+  title.value = sanitizeSpreadsheetText(results.survey.title);
+  title.font = { bold: true, color: { argb: 'FFFFFFFF' }, size: 14 };
+  title.fill = solidFill(HEADER_FILL);
+  title.alignment = { vertical: 'middle', horizontal: 'center' };
+  sheet.getRow(1).height = 28;
+
+  const headerRow = sheet.getRow(2);
+  headerRow.values = ['№ питання', 'Питання', '№ відповіді', 'Відповідь'];
+  styleHeaderRow(headerRow);
+
+  for (const question of results.questions) {
+    if (question.type !== SurveyQuestionType.TEXT) continue;
+
+    question.answers.forEach((answer, index) => {
+      const row = sheet.addRow([
+        question.order + 1,
+        sanitizeSpreadsheetText(question.text),
+        index + 1,
+        sanitizeSpreadsheetText(answer),
+      ]);
+      styleDataRow(row);
+      alignCellsLeft(row, 2, 4);
+    });
+  }
+
+  sheet.autoFilter = {
+    from: { row: 2, column: 1 },
+    to: { row: 2, column: 4 },
+  };
+  sheet.columns = [{ width: 12 }, { width: 54 }, { width: 14 }, { width: 80 }];
+}
+
+function styleHeaderRow(row: ExcelJS.Row): void {
+  row.height = 28;
+  row.eachCell((cell) => {
+    cell.font = { bold: true, color: { argb: 'FF1E3A8A' } };
+    cell.fill = solidFill(SUBHEADER_FILL);
+    cell.alignment = {
+      vertical: 'middle',
+      horizontal: 'center',
+      wrapText: true,
+    };
+    cell.border = thinBorder();
+  });
+}
+
+function styleDataRow(row: ExcelJS.Row): void {
+  row.eachCell((cell) => {
+    cell.alignment = { vertical: 'top', wrapText: true };
+    cell.border = thinBorder();
+  });
+}
+
+function alignCellsLeft(
+  row: ExcelJS.Row,
+  fromColumn: number,
+  toColumn: number,
+): void {
+  for (let column = fromColumn; column <= toColumn; column += 1) {
+    const cell = row.getCell(column);
+    cell.alignment = {
+      ...cell.alignment,
+      horizontal: 'left',
+      wrapText: true,
+    };
+  }
+}
+
+function thinBorder(): Partial<ExcelJS.Borders> {
+  const side: Partial<ExcelJS.Border> = {
+    style: 'thin',
+    color: { argb: BORDER_COLOR },
+  };
+  return { top: side, left: side, bottom: side, right: side };
+}
+
+function solidFill(color: string): ExcelJS.Fill {
+  return {
+    type: 'pattern',
+    pattern: 'solid',
+    fgColor: { argb: `FF${color}` },
+  };
+}
+
+function sanitizeSpreadsheetText(value: string | number): string | number {
+  if (typeof value === 'number') return value;
+  return /^\s*[=+\-@\t\r]/.test(value) ? `'${value}` : value;
+}
+
+function escapeCsvCell(value: string): string {
+  const safeValue = String(sanitizeSpreadsheetText(value));
+  if (/[;"\n\r]/.test(safeValue)) {
+    return `"${safeValue.replace(/"/g, '""')}"`;
+  }
+  return safeValue;
+}
+
+function formatDateTime(value?: string): string {
+  if (!value) return '';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '';
+  return new Intl.DateTimeFormat('uk-UA', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+    timeZone: 'Europe/Kyiv',
+  }).format(date);
+}
+
+function formatNumber(value: number): string {
+  return new Intl.NumberFormat('uk-UA', {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2,
+  }).format(value);
+}
+
+function surveyStatusLabel(status: SurveyStatus): string {
+  const labels: Record<SurveyStatus, string> = {
+    [SurveyStatus.DRAFT]: 'Чернетка',
+    [SurveyStatus.ACTIVE]: 'Активне',
+    [SurveyStatus.CLOSED]: 'Закрите',
+  };
+  return labels[status];
+}
+
+function surveyTargetLabel(targetType: SurveyTargetType): string {
+  const labels: Record<SurveyTargetType, string> = {
+    [SurveyTargetType.ALL]: 'Усі студенти',
+    [SurveyTargetType.TEACHERS]: 'Усі викладачі',
+    [SurveyTargetType.STUDENTS_TEACHERS]: 'Студенти та викладачі',
+    [SurveyTargetType.GROUPS]: 'Навчальні групи',
+    [SurveyTargetType.COURSE]: 'Студенти курсів',
+  };
+  return labels[targetType];
+}
+
+function questionTypeLabel(type: SurveyQuestionType): string {
+  const labels: Record<SurveyQuestionType, string> = {
+    [SurveyQuestionType.SINGLE]: 'Один варіант',
+    [SurveyQuestionType.MULTIPLE]: 'Декілька варіантів',
+    [SurveyQuestionType.RATING]: 'Оцінка 1–5',
+    [SurveyQuestionType.TEXT]: 'Текстова відповідь',
+  };
+  return labels[type];
+}

--- a/server/src/surveys/surveys.controller.ts
+++ b/server/src/surveys/surveys.controller.ts
@@ -3,7 +3,6 @@ import {
   Controller,
   Delete,
   Get,
-  Header,
   Param,
   Patch,
   Post,
@@ -13,7 +12,13 @@ import {
   Res,
   UseGuards,
 } from '@nestjs/common';
-import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import {
+  ApiBearerAuth,
+  ApiOkResponse,
+  ApiOperation,
+  ApiProduces,
+  ApiTags,
+} from '@nestjs/swagger';
 import { Response } from 'express';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { Roles, RolesGuard } from '../auth/roles.guard';
@@ -21,6 +26,10 @@ import { AuthenticatedRequest } from '../common/types/authenticated-request';
 import { Role } from '../common/types/roles.enum';
 import { CreateSurveyDto } from './dto/create-survey.dto';
 import { SubmitSurveyResponseDto } from './dto/submit-survey-response.dto';
+import {
+  SurveyExportFormat,
+  SurveyExportQueryDto,
+} from './dto/survey-export-query.dto';
 import { SurveyQueryDto } from './dto/survey-query.dto';
 import { UpdateSurveyDto } from './dto/update-survey.dto';
 import { SurveysService } from './surveys.service';
@@ -121,18 +130,50 @@ export class SurveysController {
 
   @Get(':id/results/export')
   @Roles(Role.ADMIN, Role.DEAN, Role.RECTOR, Role.PRESIDENT)
-  @Header('Content-Type', 'text/csv; charset=utf-8')
-  @ApiOperation({ summary: 'Export aggregated survey results as CSV' })
+  @ApiOperation({
+    summary: 'Export closed survey results as CSV or XLSX',
+  })
+  @ApiProduces(
+    'text/csv',
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  )
+  @ApiOkResponse({
+    description: 'CSV or XLSX report file',
+    schema: { type: 'string', format: 'binary' },
+  })
   async exportResults(
     @Param('id') id: string,
+    @Query() query: SurveyExportQueryDto,
     @Request() req: AuthenticatedRequest,
-    @Res({ passthrough: true }) res: Response,
+    @Res() res: Response,
   ) {
-    const csv = await this.surveysService.exportResultsCsv(id, req.user);
+    const format = query.format ?? SurveyExportFormat.CSV;
+    res.setHeader('Cache-Control', 'private, no-store');
+
+    if (format === SurveyExportFormat.XLSX) {
+      const workbook = await this.surveysService.exportResultsXlsx(
+        id,
+        req.user,
+      );
+      res.setHeader(
+        'Content-Type',
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      );
+      res.setHeader('Content-Length', workbook.length);
+      res.setHeader(
+        'Content-Disposition',
+        `attachment; filename="survey-${id}-results.xlsx"`,
+      );
+      return res.send(workbook);
+    }
+
+    const csvBuffer = await this.surveysService.exportResultsCsv(id, req.user);
+    res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+    res.setHeader('Content-Length', csvBuffer.length);
     res.setHeader(
       'Content-Disposition',
       `attachment; filename="survey-${id}-results.csv"`,
     );
-    return csv;
+    return res.send(csvBuffer);
   }
 }

--- a/server/src/surveys/surveys.service.spec.ts
+++ b/server/src/surveys/surveys.service.spec.ts
@@ -1,4 +1,8 @@
-import { ConflictException, ForbiddenException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+} from '@nestjs/common';
 import { Types } from 'mongoose';
 import { NotificationType } from '../notifications/dto/create-notification.dto';
 import { NotificationsService } from '../notifications/notifications.service';
@@ -371,6 +375,7 @@ describe('SurveysService', () => {
     const draftSurvey = createSurveyDoc({
       status: SurveyStatus.DRAFT,
       startDate: new Date('2099-01-01T00:00:00.000Z'),
+      endDate: new Date('2099-01-02T00:00:00.000Z'),
       save: jest.fn().mockImplementation(function save(this: {
         status: SurveyStatus;
         startDate?: Date;
@@ -404,6 +409,25 @@ describe('SurveysService', () => {
       }),
     );
     expect(notificationsService.createMany).not.toHaveBeenCalled();
+  });
+
+  it('rejects publishing a legacy draft without lifecycle dates', async () => {
+    const legacyDraft = createSurveyDoc({
+      status: SurveyStatus.DRAFT,
+      startDate: undefined,
+      endDate: undefined,
+    });
+    surveyModel.findById.mockReturnValueOnce(execQuery(legacyDraft));
+
+    await expect(
+      service.publish(legacyDraft._id.toString(), {
+        sub: legacyDraft.createdBy.toString(),
+        login: 'admin',
+        role: Role.ADMIN,
+      }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+
+    expect(surveyModel.findOneAndUpdate).not.toHaveBeenCalled();
   });
 
   it('creates one teacher-only new_survey notification on all-teachers publish', async () => {

--- a/server/src/surveys/surveys.service.ts
+++ b/server/src/surveys/surveys.service.ts
@@ -23,6 +23,10 @@ import { SubmitSurveyResponseDto } from './dto/submit-survey-response.dto';
 import { SurveyQueryDto } from './dto/survey-query.dto';
 import { UpdateSurveyDto } from './dto/update-survey.dto';
 import {
+  buildSurveyResultsCsv,
+  buildSurveyResultsXlsx,
+} from './survey-results-exporter';
+import {
   Survey,
   SurveyCompletion,
   SurveyCompletionDocument,
@@ -64,6 +68,7 @@ export interface SurveyView {
   endDate?: string;
   publishedAt?: string;
   closedAt?: string;
+  expectedRecipients?: number;
   createdAt?: string;
   updatedAt?: string;
   completed?: boolean;
@@ -410,14 +415,21 @@ export class SurveysService {
     }
 
     const now = new Date();
-    if (survey.endDate && survey.endDate <= now) {
+    if (!survey.startDate || !survey.endDate) {
+      throw new BadRequestException(
+        'Вкажіть дату початку та дату завершення опитування',
+      );
+    }
+    if (survey.endDate <= survey.startDate) {
+      throw new BadRequestException(
+        'Дата завершення повинна бути пізніше дати початку',
+      );
+    }
+    if (survey.endDate <= now) {
       throw new BadRequestException('Дата завершення вже минула');
     }
-    if (
-      (survey.targetType === SurveyTargetType.GROUPS ||
-        survey.targetType === SurveyTargetType.COURSE) &&
-      (await this.countExpectedRecipients(survey)) === 0
-    ) {
+    const expectedRecipients = await this.countExpectedRecipients(survey);
+    if (expectedRecipients === 0) {
       throw new BadRequestException(
         'Для вибраної аудиторії не знайдено активних отримувачів',
       );
@@ -429,8 +441,9 @@ export class SurveysService {
         {
           $set: {
             status: SurveyStatus.ACTIVE,
-            startDate: survey.startDate ?? now,
+            startDate: survey.startDate,
             publishedAt: now,
+            expectedRecipients,
           },
           $unset: { closedAt: 1 },
         },
@@ -620,18 +633,37 @@ export class SurveysService {
 
     const survey = await this.getSurveyOrThrow(id);
     this.ensureCanViewResults(survey, user);
+    this.ensureResultsAvailable(survey);
 
+    return this.buildResults(survey);
+  }
+
+  async exportResultsCsv(id: string, user: AuthenticatedUser): Promise<Buffer> {
+    const results = await this.getExportableResults(id, user);
+    return Buffer.from(buildSurveyResultsCsv(results), 'utf8');
+  }
+
+  async exportResultsXlsx(
+    id: string,
+    user: AuthenticatedUser,
+  ): Promise<Buffer> {
+    const results = await this.getExportableResults(id, user);
+    return buildSurveyResultsXlsx(results);
+  }
+
+  private async buildResults(
+    survey: SurveyDocument,
+  ): Promise<SurveyResultsView> {
     const questions = await this.getQuestionsForSurvey(survey._id);
-    const [responses, totalCompletions, expectedRecipients] = await Promise.all(
-      [
-        this.responseModel
-          .find({ survey: survey._id })
-          .sort({ submittedAt: 1 })
-          .exec(),
-        this.completionModel.countDocuments({ survey: survey._id }).exec(),
-        this.countExpectedRecipients(survey),
-      ],
-    );
+    const [responses, totalCompletions] = await Promise.all([
+      this.responseModel
+        .find({ survey: survey._id })
+        .sort({ submittedAt: 1 })
+        .exec(),
+      this.completionModel.countDocuments({ survey: survey._id }).exec(),
+    ]);
+    const expectedRecipients =
+      survey.expectedRecipients ?? (await this.countExpectedRecipients(survey));
 
     return {
       survey: this.formatSurvey(survey, questions),
@@ -644,87 +676,17 @@ export class SurveysService {
     };
   }
 
-  async exportResultsCsv(id: string, user: AuthenticatedUser): Promise<string> {
-    const results = await this.getResults(id, user);
-    const rows = [
-      [
-        'question_order',
-        'question_type',
-        'question_text',
-        'metric',
-        'value',
-        'count',
-        'total',
-        'average',
-      ],
-    ];
+  private async getExportableResults(
+    id: string,
+    user: AuthenticatedUser,
+  ): Promise<SurveyResultsView> {
+    await this.closeExpiredSurveys();
 
-    for (const question of results.questions) {
-      if (
-        question.type === SurveyQuestionType.SINGLE ||
-        question.type === SurveyQuestionType.MULTIPLE
-      ) {
-        for (const option of question.options) {
-          rows.push([
-            String(question.order),
-            question.type,
-            question.text,
-            'option',
-            option.value,
-            String(option.count),
-            String(question.totalAnswers),
-            '',
-          ]);
-        }
-        continue;
-      }
+    const survey = await this.getSurveyOrThrow(id);
+    this.ensureCanViewResults(survey, user);
+    this.ensureExportAvailable(survey);
 
-      if (question.type === SurveyQuestionType.RATING) {
-        rows.push([
-          String(question.order),
-          question.type,
-          question.text,
-          'average',
-          '',
-          '',
-          String(question.totalAnswers),
-          question.average === null ? '' : String(question.average),
-        ]);
-
-        for (const item of question.distribution) {
-          rows.push([
-            String(question.order),
-            question.type,
-            question.text,
-            'rating',
-            String(item.rating),
-            String(item.count),
-            String(question.totalAnswers),
-            question.average === null ? '' : String(question.average),
-          ]);
-        }
-        continue;
-      }
-
-      if (question.type === SurveyQuestionType.TEXT) {
-        for (const answer of question.answers) {
-          rows.push([
-            String(question.order),
-            question.type,
-            question.text,
-            'text',
-            answer,
-            '1',
-            String(question.totalAnswers),
-            '',
-          ]);
-        }
-      }
-    }
-
-    return `\uFEFF${rows
-      .map((row) => row.map((value) => this.escapeCsv(value)).join(','))
-      .join('\n')}\n`;
+    return this.buildResults(survey);
   }
 
   private async ensureCanRespond(
@@ -813,6 +775,22 @@ export class SurveysService {
     if (user.role === Role.DEAN && !this.canManageSurvey(survey, user)) {
       throw new ForbiddenException(
         'Декан може переглядати результати лише власних опитувань',
+      );
+    }
+  }
+
+  private ensureResultsAvailable(survey: SurveyDocument): void {
+    if (survey.status === SurveyStatus.DRAFT) {
+      throw new BadRequestException(
+        'Результати доступні лише після публікації опитування',
+      );
+    }
+  }
+
+  private ensureExportAvailable(survey: SurveyDocument): void {
+    if (survey.status !== SurveyStatus.CLOSED) {
+      throw new BadRequestException(
+        'Експорт результатів доступний лише після закриття опитування',
       );
     }
   }
@@ -1131,17 +1109,23 @@ export class SurveysService {
   private normalizeSurveyDates(
     startDate?: string,
     endDate?: string,
-  ): { startDate?: Date; endDate?: Date } {
-    const normalizedStart = startDate ? new Date(startDate) : undefined;
-    const normalizedEnd = endDate ? new Date(endDate) : undefined;
+  ): { startDate: Date; endDate: Date } {
+    if (!startDate || !endDate) {
+      throw new BadRequestException(
+        'Вкажіть дату початку та дату завершення опитування',
+      );
+    }
 
-    if (normalizedStart && Number.isNaN(normalizedStart.getTime())) {
+    const normalizedStart = new Date(startDate);
+    const normalizedEnd = new Date(endDate);
+
+    if (Number.isNaN(normalizedStart.getTime())) {
       throw new BadRequestException('Некоректна дата початку');
     }
-    if (normalizedEnd && Number.isNaN(normalizedEnd.getTime())) {
+    if (Number.isNaN(normalizedEnd.getTime())) {
       throw new BadRequestException('Некоректна дата завершення');
     }
-    if (normalizedStart && normalizedEnd && normalizedEnd <= normalizedStart) {
+    if (normalizedEnd <= normalizedStart) {
       throw new BadRequestException(
         'Дата завершення повинна бути пізніше дати початку',
       );
@@ -1422,6 +1406,9 @@ export class SurveysService {
         ? { publishedAt: survey.publishedAt.toISOString() }
         : {}),
       ...(survey.closedAt ? { closedAt: survey.closedAt.toISOString() } : {}),
+      ...(survey.expectedRecipients === undefined
+        ? {}
+        : { expectedRecipients: survey.expectedRecipients }),
       ...(survey.createdAt
         ? { createdAt: survey.createdAt.toISOString() }
         : {}),
@@ -1505,13 +1492,5 @@ export class SurveysService {
 
   private escapeRegex(value: string): string {
     return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  }
-
-  private escapeCsv(value: string): string {
-    const safeValue = /^[=+\-@\t\r]/.test(value) ? `'${value}` : value;
-    if (/[",\n\r]/.test(safeValue)) {
-      return `"${safeValue.replace(/"/g, '""')}"`;
-    }
-    return safeValue;
   }
 }

--- a/server/test/surveys.e2e-spec.ts
+++ b/server/test/surveys.e2e-spec.ts
@@ -3,7 +3,9 @@ import { getConnectionToken } from '@nestjs/mongoose';
 import { JwtService } from '@nestjs/jwt';
 import { NestExpressApplication } from '@nestjs/platform-express';
 import { Test, TestingModule } from '@nestjs/testing';
+import * as ExcelJS from 'exceljs';
 import { Connection, Types } from 'mongoose';
+import type { Response as SuperAgentResponse } from 'superagent';
 import * as request from 'supertest';
 import { GenericContainer, StartedTestContainer, Wait } from 'testcontainers';
 import { AppModule } from '../src/app.module';
@@ -19,6 +21,16 @@ import { SeedService } from '../src/seed-data/seed.service';
 const SETUP_TIMEOUT = 120_000;
 const TEST_JWT_SECRET = 'surveys-e2e-secret-with-sufficient-entropy';
 const TEST_CSRF_SECRET = 'surveys-e2e-csrf-secret-with-sufficient-entropy';
+
+const parseBinaryResponse = (
+  response: SuperAgentResponse,
+  callback: (error: Error | null, body: Buffer) => void,
+): void => {
+  const chunks: Buffer[] = [];
+  response.on('data', (chunk: Buffer) => chunks.push(Buffer.from(chunk)));
+  response.on('end', () => callback(null, Buffer.concat(chunks)));
+  response.on('error', (error: Error) => callback(error, Buffer.alloc(0)));
+};
 
 type Actor = {
   id: Types.ObjectId;
@@ -198,6 +210,7 @@ describe('Surveys (e2e)', () => {
     groupId: Types.ObjectId,
     overrides: Record<string, unknown> = {},
   ): Promise<SurveyBody> => {
+    const now = Date.now();
     const response = await request(app.getHttpServer())
       .post('/api/surveys')
       .set('Authorization', `Bearer ${actor.token}`)
@@ -207,6 +220,8 @@ describe('Surveys (e2e)', () => {
         anonymous: true,
         targetType: SurveyTargetType.GROUPS,
         targetIds: [groupId.toHexString()],
+        startDate: new Date(now - 60_000).toISOString(),
+        endDate: new Date(now + 24 * 60 * 60 * 1000).toISOString(),
         questions: [
           {
             type: SurveyQuestionType.SINGLE,
@@ -257,6 +272,7 @@ describe('Surveys (e2e)', () => {
   it('enforces manager ownership and preserves scheduled publication', async () => {
     const fixture = await seedFixture();
     const futureStart = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    const futureEnd = new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString();
 
     await request(app.getHttpServer())
       .post('/api/surveys')
@@ -264,8 +280,26 @@ describe('Surveys (e2e)', () => {
       .send({})
       .expect(403);
 
+    await request(app.getHttpServer())
+      .post('/api/surveys')
+      .set('Authorization', `Bearer ${fixture.admin.token}`)
+      .send({
+        title: 'Survey without lifecycle dates',
+        targetType: SurveyTargetType.ALL,
+        questions: [
+          {
+            type: SurveyQuestionType.TEXT,
+            text: 'Comment',
+            required: true,
+            order: 0,
+          },
+        ],
+      })
+      .expect(400);
+
     const draft = await createSurvey(fixture.deanA, fixture.groupAId, {
       startDate: futureStart,
+      endDate: futureEnd,
     });
 
     const deanBList = await request(app.getHttpServer())
@@ -278,6 +312,11 @@ describe('Surveys (e2e)', () => {
       .get(`/api/surveys/${draft.id}/results`)
       .set('Authorization', `Bearer ${fixture.deanB.token}`)
       .expect(403);
+
+    await request(app.getHttpServer())
+      .get(`/api/surveys/${draft.id}/results`)
+      .set('Authorization', `Bearer ${fixture.deanA.token}`)
+      .expect(400);
 
     await request(app.getHttpServer())
       .patch(`/api/surveys/${draft.id}/close`)
@@ -410,7 +449,7 @@ describe('Surveys (e2e)', () => {
     ]);
   });
 
-  it('returns live aggregate statistics and neutralizes CSV formulas', async () => {
+  it('returns live statistics and exports secure CSV/XLSX only after closing', async () => {
     const fixture = await seedFixture();
     const draft = await createSurvey(fixture.admin, fixture.groupAId);
     const survey = await publishSurvey(fixture.admin, draft.id);
@@ -429,6 +468,11 @@ describe('Surveys (e2e)', () => {
       })
       .expect(201);
 
+    await collection('User').updateOne(
+      { _id: fixture.outsider.id },
+      { $set: { 'studentProfile.group': fixture.groupAId } },
+    );
+
     const results = await request(app.getHttpServer())
       .get(`/api/surveys/${survey.id}/results`)
       .set('Authorization', `Bearer ${fixture.admin.token}`)
@@ -445,12 +489,80 @@ describe('Surveys (e2e)', () => {
       fixture.studentA.id.toHexString(),
     );
 
+    await request(app.getHttpServer())
+      .get(`/api/surveys/${survey.id}/results/export`)
+      .set('Authorization', `Bearer ${fixture.admin.token}`)
+      .expect(400);
+
+    await request(app.getHttpServer())
+      .get(`/api/surveys/${survey.id}/results/export?format=xlsx`)
+      .set('Authorization', `Bearer ${fixture.admin.token}`)
+      .expect(400);
+
+    await request(app.getHttpServer())
+      .patch(`/api/surveys/${survey.id}/close`)
+      .set('Authorization', `Bearer ${fixture.admin.token}`)
+      .expect(200);
+
     const csv = await request(app.getHttpServer())
       .get(`/api/surveys/${survey.id}/results/export`)
       .set('Authorization', `Bearer ${fixture.admin.token}`)
+      .buffer(true)
+      .parse(parseBinaryResponse)
       .expect(200)
-      .expect('Content-Type', /text\/csv/);
-    expect(csv.text).toContain(`'=HYPERLINK`);
+      .expect('Content-Type', /text\/csv/)
+      .expect(
+        'Content-Disposition',
+        `attachment; filename="survey-${survey.id}-results.csv"`,
+      )
+      .expect('Cache-Control', 'private, no-store');
+    expect(Buffer.isBuffer(csv.body)).toBe(true);
+    const csvBuffer = csv.body as Buffer;
+    expect([...csvBuffer.subarray(0, 3)]).toEqual([0xef, 0xbb, 0xbf]);
+    const csvText = csvBuffer.toString('utf8');
+    expect(csvText.startsWith('\uFEFF')).toBe(true);
+    expect(csvText.split('\r\n')[0]).toContain(
+      'Опитування;Статус;Анонімне;Цільова аудиторія',
+    );
+    expect(csvText).toContain(`'=HYPERLINK`);
+
+    const xlsx = await request(app.getHttpServer())
+      .get(`/api/surveys/${survey.id}/results/export?format=xlsx`)
+      .set('Authorization', `Bearer ${fixture.admin.token}`)
+      .buffer(true)
+      .parse(parseBinaryResponse)
+      .expect(200)
+      .expect(
+        'Content-Type',
+        /application\/vnd\.openxmlformats-officedocument\.spreadsheetml\.sheet/,
+      )
+      .expect(
+        'Content-Disposition',
+        `attachment; filename="survey-${survey.id}-results.xlsx"`,
+      )
+      .expect('Cache-Control', 'private, no-store');
+    expect(Buffer.isBuffer(xlsx.body)).toBe(true);
+
+    const workbook = new ExcelJS.Workbook();
+    const workbookData = Uint8Array.from(xlsx.body as Buffer).buffer;
+    await workbook.xlsx.load(workbookData);
+    expect(workbook.worksheets.map((sheet) => sheet.name)).toEqual([
+      'Зведення',
+      'Розподіл відповідей',
+      'Текстові відповіді',
+    ]);
+    expect(workbook.getWorksheet('Зведення')?.getCell('A1').value).toBe(
+      'Результати опитування',
+    );
+    expect(workbook.getWorksheet('Зведення')?.getColumn(1).width).toBe(38);
+    expect(
+      workbook.getWorksheet('Текстові відповіді')?.getCell('D3').value,
+    ).toBe(`'=HYPERLINK("https://example.test")`);
+
+    await request(app.getHttpServer())
+      .get(`/api/surveys/${survey.id}/results/export?format=pdf`)
+      .set('Authorization', `Bearer ${fixture.admin.token}`)
+      .expect(400);
   });
 
   it('closes an active survey and rejects further responses', async () => {


### PR DESCRIPTION
<details>
<summary><strong>Українська версія</strong></summary>

## Опис

Цей PR завершує ревізію `SurveysModule`, посилює життєвий цикл опитувань і додає повноцінний захищений експорт результатів у CSV та XLSX.

## Backend

- дата початку та дата завершення опитування стали обов’язковими;
- дата завершення повинна бути пізнішою за дату початку;
- прибрано автоматичне встановлення дати початку під час публікації;
- заборонено публікацію старих або неповних чернеток без коректного періоду;
- під час публікації фіксується кількість активних отримувачів;
- історичний відсоток проходження більше не змінюється після переведення студентів між групами або зміни їхнього статусу;
- результати чернеток недоступні;
- експорт результатів дозволений лише після закриття опитування;
- додано підтримку форматів `CSV` та `XLSX`;
- файли повертаються як бінарні відповіді з коректними `Content-Type`, `Content-Disposition`, `Content-Length` та `Cache-Control: private, no-store`.

## CSV

- кодування UTF-8 з BOM;
- Excel-сумісний роздільник `;`;
- завершення рядків CRLF;
- українські назви колонок;
- структуровані метадані, питання та статистика;
- захист від spreadsheet formula injection.

## XLSX

Додано окремі аркуші:

- `Зведення`;
- `Розподіл відповідей`;
- `Текстові відповіді`.

Також реалізовано:

- стилізовані заголовки;
- закріплені рядки;
- автофільтри;
- форматування дат, чисел і відсотків;
- читабельну ширину колонок;
- захист текстових значень від spreadsheet injection.

## Frontend

- поля початку та завершення позначені як обов’язкові;
- додано frontend-валідацію періоду;
- для чернеток приховано недоступну кнопку результатів;
- для активних опитувань показуються live-результати без кнопок експорту;
- фонове оновлення результатів виконується лише для активних опитувань;
- після закриття доступні окремі кнопки експорту CSV та XLSX;
- додано українські й англійські переклади повідомлень та елементів керування.

## Безпека

- RBAC для результатів та експорту збережено;
- анонімні результати не розкривають ідентифікатори респондентів;
- експорт захищений від spreadsheet injection;
- некоректні формати експорту відхиляються;
- production dependency audit не виявив уразливостей.

## Перевірки

- Server lint — успішно;
- Server build — успішно;
- Client lint — успішно;
- Client typecheck — успішно;
- Client production build — успішно;
- Backend unit tests — 83/83;
- Surveys service tests — 11/11;
- Surveys MongoDB E2E — 5/5;
- npm audit для root, client і server — 0 vulnerabilities;
- `git diff --check` — без помилок.

</details>

## Overview

This PR completes the `SurveysModule` revision, strengthens the survey lifecycle, and adds secure CSV and XLSX result exports.

## Backend

- require explicit survey start and end dates;
- validate that the end date is later than the start date;
- remove automatic start-date assignment during publication;
- reject legacy or incomplete drafts without valid lifecycle dates;
- capture the expected audience size at publication time;
- preserve historical completion statistics after user or group changes;
- prevent access to draft results;
- allow exports only after a survey is closed;
- add binary CSV and XLSX responses with secure cache and download headers.

## CSV Export

- UTF-8 BOM encoding;
- Excel-compatible semicolon delimiter;
- CRLF line endings;
- Ukrainian column names;
- structured survey metadata and question statistics;
- spreadsheet formula injection protection.

## XLSX Export

The workbook contains:

- `Зведення`;
- `Розподіл відповідей`;
- `Текстові відповіді`.

It also includes:

- styled headers;
- frozen rows;
- automatic filters;
- date, number, and percentage formatting;
- readable column widths;
- spreadsheet injection protection.

## Frontend

- mark start and end dates as required;
- add client-side lifecycle validation;
- hide unavailable result actions for drafts;
- show live statistics without export actions for active surveys;
- poll results only while a survey is active;
- provide separate CSV and XLSX export actions after closure;
- add Ukrainian and English translations.

## Security

- preserve result and export RBAC restrictions;
- prevent respondent identity exposure for anonymous surveys;
- reject unsupported export formats;
- protect CSV and XLSX cells against spreadsheet injection;
- return reports with `Cache-Control: private, no-store`.

## Verification

- Server lint and build passed;
- Client lint, typecheck, and production build passed;
- Backend unit tests: 83/83 passed;
- Surveys service tests: 11/11 passed;
- Surveys MongoDB E2E tests: 5/5 passed;
- root, client, and server production audits: 0 vulnerabilities;
- `git diff --check` passed.

##

Closed #22 
Closed #27 