### PR TITLE
fix(courses): unify finalized elective rosters across teacher workflows

### DIFF
--- a/server/src/courses/courses/courses.service.ts
+++ b/server/src/courses/courses/courses.service.ts
@@ -109,7 +109,7 @@ export class CoursesService {
 
     if (
       courseAssignment.source === CourseAssignmentSource.ELECTIVE &&
-      !courseAssignment.enrolledStudents.some(
+      !(courseAssignment.enrolledStudents ?? []).some(
         (enrolledStudent) => toId(enrolledStudent) === userId,
       )
     ) {
@@ -177,31 +177,61 @@ export class CoursesService {
     role: Role,
   ): Promise<UserDto[]> {
     const ca = await this.validateOwnership(courseAssignmentId, userId, role);
-    const filter: Record<string, unknown> = {
-      role: Role.STUDENT,
-      status: 'active',
-      'studentProfile.group': ca.group,
-    };
-
-    if (
-      ca.source === CourseAssignmentSource.ELECTIVE &&
-      ca.enrolledStudents.length > 0
-    ) {
-      filter._id = {
-        $in: ca.enrolledStudents
-          .map((student) => toId(student))
-          .filter((id) => Types.ObjectId.isValid(id))
-          .map((id) => new Types.ObjectId(id)),
-      };
-    }
 
     const students = await this.userModel
-      .find(filter as never)
+      .find(this.buildCourseStudentRosterFilter(ca) as never)
       .sort({ lastName: 1, firstName: 1, middleName: 1 })
       .lean()
       .exec();
 
     return transformToDtoArray(UserDto, students);
+  }
+
+  buildCourseStudentRosterFilter(
+    courseAssignment: Pick<
+      CourseAssignment,
+      'group' | 'source' | 'enrolledStudents'
+    >,
+  ): Record<string, unknown> {
+    const groupId = toId(courseAssignment.group);
+    this.assertValidObjectId(groupId, 'групи');
+
+    const filter: Record<string, unknown> = {
+      role: Role.STUDENT,
+      status: 'active',
+      'studentProfile.group': new Types.ObjectId(groupId),
+    };
+
+    if (courseAssignment.source === CourseAssignmentSource.ELECTIVE) {
+      filter._id = {
+        $in: this.normalizeObjectIds(courseAssignment.enrolledStudents ?? []),
+      };
+    }
+
+    return filter;
+  }
+
+  async assertStudentBelongsToCourseAssignment(
+    courseAssignment: Pick<
+      CourseAssignment,
+      'group' | 'source' | 'enrolledStudents'
+    >,
+    studentId: string,
+  ): Promise<void> {
+    this.assertValidObjectId(studentId, 'студента');
+
+    const studentExists = await this.userModel
+      .exists({
+        $and: [
+          this.buildCourseStudentRosterFilter(courseAssignment),
+          { _id: new Types.ObjectId(studentId) },
+        ],
+      } as never)
+      .exec();
+
+    if (!studentExists) {
+      throw new BadRequestException('Студент не зарахований на цю дисципліну');
+    }
   }
 
   async findMy(
@@ -342,14 +372,30 @@ export class CoursesService {
     }
 
     if (params.role === Role.STUDENT) {
-      if (!params.groupId || !Types.ObjectId.isValid(params.groupId)) {
+      if (
+        !params.groupId ||
+        !Types.ObjectId.isValid(params.groupId) ||
+        !Types.ObjectId.isValid(params.userId)
+      ) {
         return false;
       }
 
       const match = await this.courseAssignmentModel
         .exists({
-          ...targetFilter,
-          group: new Types.ObjectId(params.groupId),
+          $and: [
+            targetFilter,
+            { group: new Types.ObjectId(params.groupId) },
+            {
+              $or: [
+                { source: { $exists: false } },
+                { source: CourseAssignmentSource.STANDARD },
+                {
+                  source: CourseAssignmentSource.ELECTIVE,
+                  enrolledStudents: new Types.ObjectId(params.userId),
+                },
+              ],
+            },
+          ],
         } as never)
         .exec();
 
@@ -365,54 +411,15 @@ export class CoursesService {
     const teacherIds = courseAssignments.map((assignment) =>
       toId(assignment.teacher),
     );
-    const groupIds = [
-      ...new Set(courseAssignments.map((assignment) => toId(assignment.group))),
-    ]
-      .filter((id) => Types.ObjectId.isValid(id))
-      .map((id) => new Types.ObjectId(id));
-
-    if (groupIds.length === 0) {
-      return [...new Set(teacherIds)];
-    }
-
-    const studentFilter: Record<string, unknown> = {
-      'studentProfile.group': { $in: groupIds },
-    };
-    const students = await this.userModel
-      .find(studentFilter as never)
-      .select('_id')
-      .lean()
-      .exec();
-    const studentIds = students.map((student) => toId(student._id));
+    const studentIds =
+      await this.findActiveStudentIdsForAssignments(courseAssignments);
 
     return [...new Set([...teacherIds, ...studentIds])];
   }
 
   async findStudentIdsByCourseTargets(targetIds: string[]): Promise<string[]> {
     const courseAssignments = await this.findCourseTargetAssignments(targetIds);
-    const groupIds = [
-      ...new Set(courseAssignments.map((assignment) => toId(assignment.group))),
-    ]
-      .filter((id) => Types.ObjectId.isValid(id))
-      .map((id) => new Types.ObjectId(id));
-
-    if (groupIds.length === 0) {
-      return [];
-    }
-
-    const studentFilter: Record<string, unknown> = {
-      role: Role.STUDENT,
-      status: 'active',
-      'studentProfile.group': { $in: groupIds },
-    };
-    const students = await this.userModel
-      .find(studentFilter as never)
-      .select('_id')
-      .lean()
-      .exec();
-    const studentIds = students.map((student) => toId(student._id));
-
-    return [...new Set(studentIds)];
+    return this.findActiveStudentIdsForAssignments(courseAssignments);
   }
 
   private async findCourseTargetAssignments(targetIds: string[]) {
@@ -430,9 +437,71 @@ export class CoursesService {
 
     return this.courseAssignmentModel
       .find(assignmentFilter as never)
-      .select('teacher group')
+      .select('teacher group source enrolledStudents')
       .lean()
       .exec();
+  }
+
+  private async findActiveStudentIdsForAssignments(
+    courseAssignments: Array<
+      Pick<
+        CourseAssignment,
+        'group' | 'source' | 'enrolledStudents' | 'teacher'
+      >
+    >,
+  ): Promise<string[]> {
+    const standardGroupIds = [
+      ...new Set(
+        courseAssignments
+          .filter(
+            (assignment) =>
+              assignment.source !== CourseAssignmentSource.ELECTIVE,
+          )
+          .map((assignment) => toId(assignment.group)),
+      ),
+    ]
+      .filter((id) => Types.ObjectId.isValid(id))
+      .map((id) => new Types.ObjectId(id));
+    const rosterFilters: Record<string, unknown>[] = [];
+
+    if (standardGroupIds.length > 0) {
+      rosterFilters.push({
+        'studentProfile.group': { $in: standardGroupIds },
+      });
+    }
+    for (const assignment of courseAssignments) {
+      if (assignment.source !== CourseAssignmentSource.ELECTIVE) {
+        continue;
+      }
+
+      const groupId = toId(assignment.group);
+      const enrolledStudents = this.normalizeObjectIds(
+        assignment.enrolledStudents ?? [],
+      );
+      if (!Types.ObjectId.isValid(groupId) || enrolledStudents.length === 0) {
+        continue;
+      }
+
+      rosterFilters.push({
+        _id: { $in: enrolledStudents },
+        'studentProfile.group': new Types.ObjectId(groupId),
+      });
+    }
+    if (rosterFilters.length === 0) {
+      return [];
+    }
+
+    const students = await this.userModel
+      .find({
+        role: Role.STUDENT,
+        status: 'active',
+        $or: rosterFilters,
+      } as never)
+      .select('_id')
+      .lean()
+      .exec();
+
+    return [...new Set(students.map((student) => toId(student._id)))];
   }
 
   private buildStudentCourseAssignmentFilter(
@@ -450,6 +519,16 @@ export class CoursesService {
         },
       ],
     };
+  }
+
+  private normalizeObjectIds(values: unknown[]): Types.ObjectId[] {
+    return [
+      ...new Set(
+        values
+          .map((value) => toId(value))
+          .filter((id) => Types.ObjectId.isValid(id)),
+      ),
+    ].map((id) => new Types.ObjectId(id));
   }
 
   private assertValidObjectId(value: string, entity: string): void {

--- a/server/src/courses/grades/dto/grade-journal-response.dto.ts
+++ b/server/src/courses/grades/dto/grade-journal-response.dto.ts
@@ -6,7 +6,7 @@ import { toId } from '../../../common/utils/to-id.util';
 export class GradeJournalResponseDto {
   @ApiProperty()
   @Expose()
-  @Transform(({ value }) => toId(value))
+  @Transform(({ obj }: { obj: { studentId?: unknown } }) => toId(obj.studentId))
   studentId: string;
 
   @ApiProperty()

--- a/server/src/courses/grades/grades.service.ts
+++ b/server/src/courses/grades/grades.service.ts
@@ -69,10 +69,14 @@ export class GradesService {
     }
 
     const assignment = submission.assignment as unknown as AssignmentDocument;
-    await this.coursesService.validateOwnership(
+    const courseAssignment = await this.coursesService.validateOwnership(
       toId(assignment.courseAssignment),
       userId,
       role,
+    );
+    await this.coursesService.assertStudentBelongsToCourseAssignment(
+      courseAssignment,
+      toId(submission.student),
     );
 
     if (submission.status === 'returned') {
@@ -115,10 +119,14 @@ export class GradesService {
     userId: string,
     role: Role,
   ): Promise<GradeResponseDto> {
-    await this.coursesService.validateOwnership(
+    const courseAssignment = await this.coursesService.validateOwnership(
       dto.courseAssignmentId,
       userId,
       role,
+    );
+    await this.coursesService.assertStudentBelongsToCourseAssignment(
+      courseAssignment,
+      dto.studentId,
     );
 
     const grade = new this.gradeModel({
@@ -153,10 +161,14 @@ export class GradesService {
       throw new NotFoundException('Оцінку не знайдено');
     }
 
-    await this.coursesService.validateOwnership(
+    const courseAssignment = await this.coursesService.validateOwnership(
       toId(grade.courseAssignment),
       userId,
       role,
+    );
+    await this.coursesService.assertStudentBelongsToCourseAssignment(
+      courseAssignment,
+      toId(grade.student),
     );
     const linkedAssignment = await this.findLinkedAssignment(grade);
     if (linkedAssignment) {
@@ -260,10 +272,15 @@ export class GradesService {
     requesterId: string,
     requesterRole: Role,
   ): Promise<PaginatedDto<GradeResponseDto>> {
-    await this.coursesService.assertCourseAssignmentAccess(
-      courseAssignmentId,
-      requesterId,
-      requesterRole,
+    const courseAssignment =
+      await this.coursesService.assertCourseAssignmentAccess(
+        courseAssignmentId,
+        requesterId,
+        requesterRole,
+      );
+    await this.coursesService.assertStudentBelongsToCourseAssignment(
+      courseAssignment,
+      studentId,
     );
 
     const { page, limit } = pagination;
@@ -299,28 +316,12 @@ export class GradesService {
     userId: string,
     role: Role,
   ): Promise<PaginatedDto<GradeJournalResponseDto>> {
-    await this.coursesService.assertCourseAssignmentAccess(
-      courseAssignmentId,
-      userId,
-      role,
-    );
-
-    const ca = await this.courseAssignmentModel
-      .findById(courseAssignmentId)
-      .populate('group')
-      .lean()
-      .exec();
-    if (!ca) {
-      return {
-        docs: [],
-        totalDocs: 0,
-        limit: pagination.limit || 10,
-        page: pagination.page || 1,
-        totalPages: 0,
-        hasNextPage: false,
-        hasPrevPage: false,
-      };
-    }
+    const courseAssignment =
+      await this.coursesService.assertCourseAssignmentAccess(
+        courseAssignmentId,
+        userId,
+        role,
+      );
 
     const { page, limit } = pagination;
     const studentOptions = {
@@ -331,7 +332,7 @@ export class GradesService {
     };
 
     const studentResult = await this.userModel.paginate(
-      { 'studentProfile.group': toId(ca.group) },
+      this.coursesService.buildCourseStudentRosterFilter(courseAssignment),
       studentOptions,
     );
 

--- a/server/src/courses/journal/lesson-journal.service.ts
+++ b/server/src/courses/journal/lesson-journal.service.ts
@@ -16,7 +16,6 @@ import { CoursesService } from '../courses/courses.service';
 import {
   CourseAssignment,
   CourseAssignmentDocument,
-  CourseAssignmentSource,
   Grade,
   GradeDocument,
   LessonJournalEntry,
@@ -300,25 +299,12 @@ export class LessonJournalService {
   private async getCourseStudentMap(
     courseAssignment: CourseAssignmentDocument,
   ): Promise<Map<string, StudentLean>> {
-    const filter: Record<string, unknown> = {
-      role: Role.STUDENT,
-      status: 'active',
-      'studentProfile.group': courseAssignment.group,
-    };
-
-    if (
-      courseAssignment.source === CourseAssignmentSource.ELECTIVE &&
-      courseAssignment.enrolledStudents.length > 0
-    ) {
-      filter._id = {
-        $in: courseAssignment.enrolledStudents.map((id) =>
-          this.toObjectId(toId(id)),
-        ),
-      };
-    }
-
     const students = await this.userModel
-      .find(filter as never)
+      .find(
+        this.coursesService.buildCourseStudentRosterFilter(
+          courseAssignment,
+        ) as never,
+      )
       .select(this.studentSelect())
       .lean<StudentLean[]>()
       .exec();

--- a/server/test/courses.e2e-spec.ts
+++ b/server/test/courses.e2e-spec.ts
@@ -11,6 +11,7 @@ import { PaginatedDto } from '../src/common/dto/paginated.dto';
 import { CourseAssignmentDto, CourseDto } from '../src/courses/courses/dto';
 import { SeedService } from '../src/seed-data/seed.service';
 import { configureApp } from '../src/app.config';
+import { CoursesService } from '../src/courses/courses/courses.service';
 
 const SET_UP_TIMEOUT = 60_000;
 
@@ -19,6 +20,7 @@ describe('Courses (e2e)', () => {
   let container: StartedTestContainer;
   let connection: Connection;
   let jwtService: JwtService;
+  let coursesService: CoursesService;
 
   beforeAll(async () => {
     container = await new GenericContainer('mongo')
@@ -43,6 +45,7 @@ describe('Courses (e2e)', () => {
 
     connection = app.get(getConnectionToken());
     jwtService = app.get(JwtService);
+    coursesService = app.get(CoursesService);
   });
 
   afterEach(async () => {
@@ -236,6 +239,82 @@ describe('Courses (e2e)', () => {
         )
         .set('Authorization', `Bearer ${accessToken}`)
         .expect(403);
+    });
+  });
+
+  describe('Elective course targets', () => {
+    it('resolves only enrolled students for access and notifications', async () => {
+      const { groupId, studentId } = await setupData();
+      const outsiderId = new Types.ObjectId();
+      const teacherId = new Types.ObjectId();
+      const electiveAssignmentId = new Types.ObjectId();
+
+      await connection.collection('users').insertMany([
+        {
+          _id: outsiderId,
+          login: 'elective_target_outsider',
+          role: Role.STUDENT,
+          email: 'elective_target_outsider@example.com',
+          firstName: 'Other',
+          lastName: 'Student',
+          status: 'active',
+          passwordHash: 'hash',
+          studentProfile: { group: groupId },
+        },
+        {
+          _id: teacherId,
+          login: 'elective_target_teacher',
+          role: Role.TEACHER,
+          email: 'elective_target_teacher@example.com',
+          firstName: 'Course',
+          lastName: 'Teacher',
+          status: 'active',
+          passwordHash: 'hash',
+        },
+      ]);
+      await connection.collection('courseassignments').insertOne({
+        _id: electiveAssignmentId,
+        course: new Types.ObjectId(),
+        teacher: teacherId,
+        group: groupId,
+        academicYear: '2026-2027',
+        semester: 1,
+        source: 'elective',
+        enrolledStudents: [studentId],
+        finalizedAt: new Date(),
+      });
+
+      const targetIds = await coursesService.findStudentIdsByCourseTargets([
+        electiveAssignmentId.toHexString(),
+      ]);
+      const recipientIds = await coursesService.findUserIdsByCourseTargets([
+        electiveAssignmentId.toHexString(),
+      ]);
+
+      expect(targetIds).toEqual([studentId.toHexString()]);
+      expect(recipientIds).toEqual(
+        expect.arrayContaining([
+          teacherId.toHexString(),
+          studentId.toHexString(),
+        ]),
+      );
+      expect(recipientIds).not.toContain(outsiderId.toHexString());
+      await expect(
+        coursesService.isUserAssignedToCourseTargets({
+          userId: studentId.toHexString(),
+          role: Role.STUDENT,
+          targetIds: [electiveAssignmentId.toHexString()],
+          groupId: groupId.toHexString(),
+        }),
+      ).resolves.toBe(true);
+      await expect(
+        coursesService.isUserAssignedToCourseTargets({
+          userId: outsiderId.toHexString(),
+          role: Role.STUDENT,
+          targetIds: [electiveAssignmentId.toHexString()],
+          groupId: groupId.toHexString(),
+        }),
+      ).resolves.toBe(false);
     });
   });
 });

--- a/server/test/grades.e2e-spec.ts
+++ b/server/test/grades.e2e-spec.ts
@@ -8,7 +8,10 @@ import { Role } from '../src/common/types/roles.enum';
 import { GenericContainer, StartedTestContainer } from 'testcontainers';
 import { NestExpressApplication } from '@nestjs/platform-express';
 import { PaginatedDto } from '../src/common/dto/paginated.dto';
-import { GradeResponseDto } from '../src/courses/grades/dto';
+import {
+  GradeJournalResponseDto,
+  GradeResponseDto,
+} from '../src/courses/grades/dto';
 import { StudentCourseResponseDto } from '../src/courses/courses/dto';
 import { SeedService } from '../src/seed-data/seed.service';
 import { configureApp } from '../src/app.config';
@@ -53,6 +56,8 @@ describe('Grades (e2e)', () => {
       await connection.collection('courses').deleteMany({});
       await connection.collection('courseassignments').deleteMany({});
       await connection.collection('grades').deleteMany({});
+      await connection.collection('lessonjournalentries').deleteMany({});
+      await connection.collection('notifications').deleteMany({});
     }
     if (app) {
       await app.close();
@@ -243,6 +248,148 @@ describe('Grades (e2e)', () => {
         )
         .set('Authorization', `Bearer ${accessToken}`)
         .expect(403);
+    });
+  });
+
+  describe('Elective course roster integrity', () => {
+    it('uses only enrolled students across course, journal and grade flows', async () => {
+      const { courseAssignmentId, groupId, studentId, teacherToken } =
+        await setupGrades();
+      const outsiderId = new Types.ObjectId();
+
+      await connection.collection('users').insertOne({
+        _id: outsiderId,
+        login: 'elective_outsider',
+        role: Role.STUDENT,
+        email: 'elective_outsider@test.com',
+        firstName: 'Other',
+        lastName: 'Student',
+        status: 'active',
+        passwordHash: 'hash',
+        studentProfile: {
+          group: groupId,
+          recordBookNumber: 'OUTSIDER-1',
+          year: 1,
+        },
+      });
+      await connection.collection('courseassignments').updateOne(
+        { _id: courseAssignmentId },
+        {
+          $set: {
+            source: 'elective',
+            enrolledStudents: [studentId],
+            finalizedAt: new Date(),
+          },
+        },
+      );
+      await connection.collection('grades').insertOne({
+        student: outsiderId,
+        courseAssignment: courseAssignmentId,
+        date: new Date('2025-02-19'),
+        type: 'current',
+        value: 7,
+        comment: 'Legacy invalid grade',
+      });
+
+      const studentsResponse = await request(app.getHttpServer())
+        .get(
+          `/api/courses/course-assignments/${courseAssignmentId.toHexString()}/students`,
+        )
+        .set('Authorization', `Bearer ${teacherToken}`)
+        .expect(200);
+      const students = studentsResponse.body as Array<{ id: string }>;
+
+      expect(students.map((student) => student.id)).toEqual([
+        studentId.toHexString(),
+      ]);
+
+      const gradesResponse = await request(app.getHttpServer())
+        .get(`/api/courses/${courseAssignmentId.toHexString()}/grades`)
+        .query({ page: 1, limit: 100 })
+        .set('Authorization', `Bearer ${teacherToken}`)
+        .expect(200);
+      const gradeJournal =
+        gradesResponse.body as PaginatedDto<GradeJournalResponseDto>;
+
+      expect(gradeJournal.totalDocs).toBe(1);
+      expect(gradeJournal.docs).toHaveLength(1);
+      expect(gradeJournal.docs[0].studentId).toBe(studentId.toHexString());
+      expect(
+        gradeJournal.docs[0].grades.every(
+          (grade) => grade.studentId === studentId.toHexString(),
+        ),
+      ).toBe(true);
+
+      await request(app.getHttpServer())
+        .post('/api/courses/grades')
+        .set('Authorization', `Bearer ${teacherToken}`)
+        .send({
+          studentId: outsiderId.toHexString(),
+          courseAssignmentId: courseAssignmentId.toHexString(),
+          type: 'current',
+          value: 10,
+        })
+        .expect(400);
+
+      await request(app.getHttpServer())
+        .get(
+          `/api/courses/${courseAssignmentId.toHexString()}/grades/student/${outsiderId.toHexString()}`,
+        )
+        .set('Authorization', `Bearer ${teacherToken}`)
+        .expect(400);
+
+      await request(app.getHttpServer())
+        .post(`/api/courses/${courseAssignmentId.toHexString()}/journal`)
+        .set('Authorization', `Bearer ${teacherToken}`)
+        .send({
+          date: '2026-06-10',
+          topic: 'Elective roster check',
+          attendance: [
+            {
+              studentId: outsiderId.toHexString(),
+              status: 'present',
+            },
+          ],
+        })
+        .expect(400);
+
+      expect(
+        await connection.collection('lessonjournalentries').countDocuments(),
+      ).toBe(0);
+    });
+
+    it('never falls back to the whole group for an empty elective roster', async () => {
+      const { courseAssignmentId, teacherToken } = await setupGrades();
+
+      await connection.collection('courseassignments').updateOne(
+        { _id: courseAssignmentId },
+        {
+          $set: {
+            source: 'elective',
+            enrolledStudents: [],
+            finalizedAt: new Date(),
+          },
+        },
+      );
+
+      const studentsResponse = await request(app.getHttpServer())
+        .get(
+          `/api/courses/course-assignments/${courseAssignmentId.toHexString()}/students`,
+        )
+        .set('Authorization', `Bearer ${teacherToken}`)
+        .expect(200);
+      expect(studentsResponse.body).toEqual([]);
+
+      const gradesResponse = await request(app.getHttpServer())
+        .get(`/api/courses/${courseAssignmentId.toHexString()}/grades`)
+        .query({ page: 1, limit: 100 })
+        .set('Authorization', `Bearer ${teacherToken}`)
+        .expect(200);
+      const gradeJournal =
+        gradesResponse.body as PaginatedDto<GradeJournalResponseDto>;
+
+      expect(gradeJournal.totalDocs).toBe(0);
+      expect(gradeJournal.docs).toEqual([]);
     });
   });
 


### PR DESCRIPTION
<details>
<summary><strong>Українська версія</strong></summary>

## Опис

Цей PR виправляє розбіжності у списках студентів фіналізованих вибіркових дисциплін у кабінеті викладача.

Раніше вкладки «Студенти» та «Журнал занять» використовували список зарахованих студентів, а вкладка «Оцінки» завантажувала всю академічну групу. Це могло призводити до відображення сторонніх студентів і некоректних академічних операцій.

## Зміни

- Додано єдине авторитетне джерело складу студентів курсу.
- Для вибіркових дисциплін враховуються лише активні студенти з `enrolledStudents`.
- Порожній список зарахованих студентів більше не замінюється всією групою.
- Уніфіковано склад студентів для:
  - вкладки «Студенти»;
  - журналу занять;
  - журналу оцінок;
  - цільових опитувань і сповіщень.
- Заборонено створення, редагування та перегляд оцінок незарахованих студентів.
- Виправлено серіалізацію `studentId` у журналі оцінок.
- Застарілі некоректні записи більше не відображаються в актуальному журналі.
- Додано E2E-тести узгодженості складу курсу та контролю доступу.

## Безпека та цілісність даних

- Виключено розкриття даних студентів, не зарахованих на дисципліну.
- Заборонено створення некоректних академічних записів.
- Опитування та сповіщення отримують лише належні учасники курсу.
- Історичні записи не видаляються автоматично, але більше не потрапляють до активного складу курсу.

## Перевірки

- Backend lint: успішно
- Backend production build: успішно
- Unit-тести: 84/84
- Grades E2E: 11/11
- Courses E2E: 8/8
- Electives та Surveys E2E: 16/16
- Frontend lint і production build: успішно
- Client і server npm audit: 0 вразливостей

</details>

## Summary

This PR fixes inconsistent student rosters across finalized elective courses in the teacher workspace.

Previously, the Students and Lesson Journal tabs used the elective enrollment list, while the Grades tab loaded every student from the academic group. This could expose unrelated students and allow invalid academic operations.

## Changes

- Added a single authoritative roster resolver for standard and elective courses.
- Restricted finalized elective courses to active students explicitly listed in `enrolledStudents`.
- Prevented empty elective rosters from falling back to the entire academic group.
- Unified student resolution across:
  - Students
  - Lesson Journal
  - Grades
  - course-target surveys and notifications
- Rejected grade creation, updates, submission grading and grade access for non-enrolled students.
- Fixed grade journal `studentId` serialization.
- Prevented legacy invalid grade records from appearing in the current elective grade journal.
- Added E2E coverage for roster consistency, access control and empty elective rosters.

## Security and Data Integrity

- Prevents exposure of students who are not enrolled in an elective course.
- Prevents unauthorized academic records from being created or modified.
- Ensures course-target notifications and surveys reach only eligible recipients.
- Existing historical records are preserved and are no longer exposed through the active roster.

## Verification

- Backend lint: passed
- Backend production build: passed
- Backend unit tests: 84/84 passed
- Grades E2E: 11/11 passed
- Courses E2E: 8/8 passed
- Electives and Surveys E2E: 16/16 passed
- Frontend lint and production build: passed
- Client and server npm audit: 0 vulnerabilities