### PR TITLE
fix(config): add explicit local demo seed bootstrap

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@
 PORT=3000
 NODE_ENV=development
 CLIENT_URL=http://localhost:5173
+# Local development: true, production: false
 SWAGGER_ENABLED=true
 
 # JWT Auth
@@ -50,7 +51,8 @@ AUDIT_OUTBOX_MAX_ATTEMPTS=10
 
 # Demo fixtures
 # Enables seeders that copy mock fixture data into MongoDB.
-# Keep false in shared dev/prod environments because demo users use a known password.
+# Fresh disposable local DB: temporarily set true in your private .env.
+# Shared dev/staging/prod: keep false because demo users use a known password.
 SEED_DEMO_DATA=false
 # Never enable in production except for disposable demo databases.
 SEED_DEMO_DATA_IN_PRODUCTION=false

--- a/README.md
+++ b/README.md
@@ -1516,6 +1516,28 @@ docker compose up --build
 - **Frontend:** http://localhost:5173
 - **Backend API:** http://localhost:3000/api
 
+Для повністю нового локального clone з порожньою MongoDB створіть `.env` з
+основного прикладу та увімкніть demo fixtures лише для disposable local DB:
+
+```powershell
+Copy-Item .env.example .env
+# у локальному .env встановіть SEED_DEMO_DATA=true
+docker compose up --build
+```
+
+`SEED_DEMO_DATA=true` створює тестових користувачів із розділу
+[Тестові дані](#15-тестові-дані). Не вмикайте цей прапорець для shared dev,
+staging або production: demo-користувачі мають відомий пароль.
+
+Якщо контейнери вже підняті з порожньою БД і `SEED_DEMO_DATA=false`, login
+поверне `401 Unauthorized`, бо в колекції `users` ще немає жодного акаунта.
+Для локальної disposable БД можна виконати одноразовий seed без перескладання
+контейнерів:
+
+```bash
+docker compose exec server npm run seed:demo
+```
+
 ### Локально
 
 ```bash
@@ -1531,6 +1553,14 @@ cd server && npm run start:dev
 
 # Термінал 2 — фронтенд
 cd client && npm run dev
+```
+
+Для локального запуску без Docker demo fixtures можна створити після підключення
+MongoDB:
+
+```bash
+cd server
+npm run seed:demo:dev
 ```
 
 ### Змінні середовища (server)
@@ -1588,6 +1618,11 @@ Demo seeders копіюють fixture-дані з `server/src/common/mock-data` 
 замовчуванням навіть із цим прапорцем; `SEED_DEMO_DATA_IN_PRODUCTION=true`
 дозволено тільки для одноразових demo-баз, бо fixture-користувачі мають відомий
 пароль.
+
+Для локального disposable запуску можна тимчасово встановити
+`SEED_DEMO_DATA=true` у власному `.env`. Для shared dev/prod залишайте
+`SEED_DEMO_DATA=false` і створюйте реальних адміністраторів контрольованою
+процедурою.
 
 У локальному `docker-compose.yml` MongoDB доступна backend-контейнеру через
 внутрішню Docker network (`mongodb:27017`) і не публікується на host-порт за

--- a/server/package.json
+++ b/server/package.json
@@ -29,6 +29,8 @@
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
+    "seed:demo": "node dist/seed-data/run-demo-seed.js",
+    "seed:demo:dev": "ts-node -r tsconfig-paths/register src/seed-data/run-demo-seed.ts",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "lint:check": "eslint \"{src,apps,libs,test}/**/*.ts\"",
     "test": "jest --runInBand",

--- a/server/src/seed-data/run-demo-seed.ts
+++ b/server/src/seed-data/run-demo-seed.ts
@@ -1,0 +1,21 @@
+import { Logger } from '@nestjs/common';
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from '../app.module';
+
+const logger = new Logger('DemoSeedCommand');
+
+async function run(): Promise<void> {
+  process.env.SEED_DEMO_DATA = 'true';
+
+  const app = await NestFactory.createApplicationContext(AppModule, {
+    logger: ['log', 'warn', 'error'],
+  });
+
+  await app.close();
+  logger.log('Demo seed command completed.');
+}
+
+void run().catch((error: unknown) => {
+  logger.error('Demo seed command failed.', error);
+  process.exitCode = 1;
+});

--- a/server/src/seed-data/seed.service.spec.ts
+++ b/server/src/seed-data/seed.service.spec.ts
@@ -6,13 +6,30 @@ type SeederMock = {
   seed: jest.Mock<Promise<void>, []>;
 };
 
+type UserModelMock = {
+  estimatedDocumentCount: jest.Mock<{
+    exec: jest.Mock<Promise<number>, []>;
+  }>;
+};
+
 function createSeeder(): SeederMock {
   const seed = jest.fn<Promise<void>, []>();
   seed.mockResolvedValue(undefined);
   return { seed };
 }
 
-function createService(env: Record<string, string | undefined> = {}) {
+function createUserModel(userCount = 1): UserModelMock {
+  const exec = jest.fn<Promise<number>, []>().mockResolvedValue(userCount);
+
+  return {
+    estimatedDocumentCount: jest.fn(() => ({ exec })),
+  };
+}
+
+function createService(
+  env: Record<string, string | undefined> = {},
+  userCount = 1,
+) {
   const configService = {
     get: jest.fn((key: string) => env[key]),
   } as unknown as ConfigService;
@@ -31,9 +48,11 @@ function createService(env: Record<string, string | undefined> = {}) {
     assignmentSeeder: createSeeder(),
     materialSeeder: createSeeder(),
   };
+  const userModel = createUserModel(userCount);
 
   const service = new SeedService(
     configService,
+    userModel as never,
     seeders.userSeeder as never,
     seeders.facultySeeder as never,
     seeders.departmentSeeder as never,
@@ -48,7 +67,7 @@ function createService(env: Record<string, string | undefined> = {}) {
     seeders.materialSeeder as never,
   );
 
-  return { service, seeders };
+  return { service, seeders, userModel };
 }
 
 describe('SeedService', () => {
@@ -69,12 +88,33 @@ describe('SeedService', () => {
   });
 
   it('does not seed demo data unless explicitly enabled', async () => {
-    const { service, seeders } = createService({ NODE_ENV: 'development' });
+    const { service, seeders, userModel } = createService({
+      NODE_ENV: 'development',
+    });
 
     await service.onModuleInit();
 
     expect(seeders.userSeeder.seed).not.toHaveBeenCalled();
     expect(seeders.materialSeeder.seed).not.toHaveBeenCalled();
+    expect(userModel.estimatedDocumentCount).toHaveBeenCalledTimes(1);
+  });
+
+  it('warns local developers when a fresh database has no users', async () => {
+    const { service } = createService({ NODE_ENV: 'development' }, 0);
+
+    await service.onModuleInit();
+
+    expect(loggerWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('No users found in MongoDB'),
+    );
+  });
+
+  it('does not inspect user count in production when demo seeding is disabled', async () => {
+    const { service, userModel } = createService({ NODE_ENV: 'production' });
+
+    await service.onModuleInit();
+
+    expect(userModel.estimatedDocumentCount).not.toHaveBeenCalled();
   });
 
   it('runs demo seeders in development when enabled', async () => {

--- a/server/src/seed-data/seed.service.ts
+++ b/server/src/seed-data/seed.service.ts
@@ -1,5 +1,8 @@
 import { Injectable, OnModuleInit, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { User } from '../users/schemas';
 import {
   UserSeeder,
   FacultySeeder,
@@ -21,6 +24,7 @@ export class SeedService implements OnModuleInit {
 
   constructor(
     private readonly configService: ConfigService,
+    @InjectModel(User.name) private readonly userModel: Model<User>,
     private readonly userSeeder: UserSeeder,
     private readonly facultySeeder: FacultySeeder,
     private readonly departmentSeeder: DepartmentSeeder,
@@ -40,6 +44,7 @@ export class SeedService implements OnModuleInit {
       this.logger.log(
         'Demo database seeding is disabled. Set SEED_DEMO_DATA=true only for local development fixtures.',
       );
+      await this.warnWhenLocalDatabaseHasNoUsers();
       return;
     }
 
@@ -75,6 +80,20 @@ export class SeedService implements OnModuleInit {
     } catch (error) {
       this.logger.error('Error during seeding:', error);
       throw error;
+    }
+  }
+
+  private async warnWhenLocalDatabaseHasNoUsers(): Promise<void> {
+    if (this.isProduction()) {
+      return;
+    }
+
+    const userCount = await this.userModel.estimatedDocumentCount().exec();
+
+    if (userCount === 0) {
+      this.logger.warn(
+        'No users found in MongoDB while demo seeding is disabled. Fresh local installations cannot log in until demo fixtures are seeded or an administrator account is created.',
+      );
     }
   }
 


### PR DESCRIPTION
<details>
<summary><strong>Українська версія</strong></summary>

## Опис

Додає безпечний і явний local demo seed flow для нового clone з порожньою MongoDB.

## Зміни

- Додано команду `seed:demo` для вже запущеного Docker-середовища.
- Додано команду `seed:demo:dev` для локальної розробки без Docker.
- Додано попередження в backend-логах, якщо база не має користувачів, а demo seed вимкнений.
- `.env.example` залишено безпечним за замовчуванням із `SEED_DEMO_DATA=false`.
- Оновлено документацію для fresh clone workflow та пояснено `401`, коли в БД немає користувачів.

## Безпека

- Demo seed залишається вимкненим за замовчуванням.
- Production примусово використовує `SEED_DEMO_DATA=false` і `SEED_DEMO_DATA_IN_PRODUCTION=false`.
- Demo-користувачі з відомим паролем вмикаються лише явно для disposable local DB.

## Перевірка

- Backend lint успішний.
- Backend build успішний.
- Unit-тести backend успішні.
- Docker Compose config validation успішна.

</details>

## Summary

Adds a safe and explicit local demo seed flow for fresh clones with an empty MongoDB database.

## Changes

- Added a `seed:demo` command for already running Docker environments.
- Added a `seed:demo:dev` command for local non-Docker development.
- Added a local-only warning when the database has no users and demo seeding is disabled.
- Kept `.env.example` safe by default with `SEED_DEMO_DATA=false`.
- Documented the fresh clone workflow and the expected 401 behavior when no users exist.

## Safety

- Demo seeding remains disabled by default.
- Production keeps `SEED_DEMO_DATA=false` and `SEED_DEMO_DATA_IN_PRODUCTION=false`.
- Demo users with known passwords are only enabled explicitly for disposable local databases.

## Verification

- Server lint passed.
- Server build passed.
- Server unit tests passed.
- Docker Compose config validation passed.