### PR TITLE
fix(references): remove read-only header badge

### DIFF
--- a/client/src/i18n.ts
+++ b/client/src/i18n.ts
@@ -838,7 +838,6 @@ const resources = {
         'Керуйте організаційною структурою, академічними групами та аудиторіями.',
       'references.readOnlySubtitle':
         'Переглядайте довідникові дані, доступні у межах ваших академічних повноважень.',
-      'references.readOnly': 'Лише перегляд',
       'references.create': 'Додати запис',
       'references.importButton': 'Імпорт',
       'references.search': 'Знайти',
@@ -1742,7 +1741,6 @@ const resources = {
         'Manage the organizational structure, academic groups, and classrooms.',
       'references.readOnlySubtitle':
         'View reference data available within your academic scope.',
-      'references.readOnly': 'Read only',
       'references.create': 'Add record',
       'references.importButton': 'Import',
       'references.search': 'Search',

--- a/client/src/pages/shared/ReferencesPage.tsx
+++ b/client/src/pages/shared/ReferencesPage.tsx
@@ -223,7 +223,7 @@ export default function ReferencesPage() {
             )}
           </p>
         </div>
-        {canManage ? (
+        {canManage && (
           <div className="flex flex-wrap gap-2">
             <button
               type="button"
@@ -258,10 +258,6 @@ export default function ReferencesPage() {
               {t("references.create")}
             </button>
           </div>
-        ) : (
-          <span className="inline-flex h-9 items-center rounded-md bg-slate-100 px-3 text-sm font-medium text-slate-600">
-            {t("references.readOnly")}
-          </span>
         )}
       </section>
 


### PR DESCRIPTION
## Summary

Removes the redundant `Read only` badge from the References page header for non-admin users.

## Changes

- Removed the visual read-only badge from `ReferencesPage`.
- Removed unused `references.readOnly` translations.