### PR TITLE
feat: add user directory pagination and executive read-only access

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Електронний Кампус МАУП — Технічна документація
 
-> Версія документа: 3.0
+> Версія документа: 3.1
 > Статус: актуальний
 
 ---
@@ -31,7 +31,7 @@
 
 ### Призначення
 
-Система є **самостійним порталом** з власною базою даних і власними критичними процесами: кабінети користувачів, розклад, курси, оцінки, опитування, сповіщення, довідники та аудит. Moodle не вбудовується в портал як внутрішній модуль і не дублюється функціонально; він залишається окремою потужною LMS-системою, до якої портал може надати лише зовнішній перехід або, за окремим рішенням, простий SSO-вхід.
+Система є **самостійним порталом** з власною базою даних і власними критичними процесами: кабінети користувачів, опитування, вибіркові дисципліни, сповіщення, довідники та аудит. Поточна реалізація також містить локальні модулі розкладу, курсів, завдань і оцінок. Погоджений цільовий стан передбачає отримання академічних даних із API МАУП та використання зовнішніх посилань на Moodle замість дублювання LMS-функцій.
 
 ```
 ┌─────────────────────────────────────────────────────────┐
@@ -56,7 +56,7 @@
 ### Ключові можливості
 
 - Особисті кабінети для **7 ролей** з різними наборами функцій
-- Перегляд розкладу (день / тиждень / місяць) з перевіркою конфліктів
+- Перегляд розкладу (день / тиждень) з перевіркою конфліктів
 - Управління навчальними матеріалами, завданнями та оцінками
 - **Система опитувань** — створення, проходження студентами та викладачами, аналіз результатів
 - **Вибіркові дисципліни** — критичний модуль: вибір студентом із запропонованого переліку та фіксація результату в кабінеті
@@ -87,8 +87,9 @@
 │  │  AuthModule · UsersModule · ScheduleModule        │   │
 │  │  CoursesModule · SurveysModule                    │   │
 │  │  NotificationsModule · ReferencesModule           │   │
-│  │  ElectiveDisciplinesModule                         │   │
-│  │  AuditLogModule                                   │   │
+│  │  ElectiveDisciplinesModule · ReportsModule         │   │
+│  │  AuditLogModule · FilesModule                      │   │
+│  │  DatabaseMigrationsModule · MaupStudentApiModule   │   │
 │  └──────────────────────────────────────────────────┘   │
 │                                                          │
 │  ┌──────────────────────────────────────────────────┐   │
@@ -117,7 +118,8 @@
 
 | Технологія      | Версія | Призначення                           |
 | --------------- | ------ | ------------------------------------- |
-| Node.js         | 20 LTS | Runtime                               |
+| Node.js         | 24.17  | Runtime                               |
+| npm             | 11.13  | Package manager                       |
 | NestJS          | 11     | Framework (модулі, DI, guards, pipes) |
 | TypeScript      | 5      | Типізація                             |
 | Passport.js     | —      | Стратегія JWT-аутентифікації          |
@@ -125,8 +127,8 @@
 | bcryptjs        | —      | Хешування паролів                     |
 | class-validator | —      | Валідація DTO                         |
 | Helmet          | —      | HTTP security headers                 |
-| Mongoose        | —      | ODM для MongoDB [Phase 2]             |
-| MongoDB         | 7      | База даних [Phase 2]                  |
+| Mongoose        | 9      | ODM для MongoDB                       |
+| MongoDB         | 7      | База даних                            |
 
 ### Фронтенд
 
@@ -192,21 +194,23 @@
 
 **Файли:** `src/users/`
 
-**Відповідальність:** управління обліковими записами, пошук, фільтрація за роллю, перегляд профілів.
+**Відповідальність:** управління обліковими записами, серверна пагінація, пошук за кількома частинами ПІБ, фільтрація за роллю та перегляд профілів. Ректор і президент мають глобальний read-only доступ до каталогу; мутації доступні лише адміністратору.
 
 **Ендпоінти та доступ:**
 
 | Метод | Шлях                       | Доступ                         |
 | ----- | -------------------------- | ------------------------------ |
-| GET   | `/users`                   | admin; president — лише студенти, read-only |
-| GET   | `/users/search?q=&role=`   | admin, president, dean, department_head; scoped |
-| GET   | `/users/:id`               | admin, president (лише студент), dean; scoped |
+| GET   | `/users?page=&limit=&role=&search=` | admin, rector, president; глобальний read-only для rector/president |
+| GET   | `/users/search?q=&role=`   | admin, rector, president, dean, department_head; scoped для dean/department_head |
+| GET   | `/users/:id`               | admin, rector, president, dean; scoped для dean |
 | GET   | `/users/group/:groupId`    | teacher+                       |
 | GET   | `/users/department/:depId` | department_head+               |
 | POST  | `/users`                   | admin                          |
 | PATCH | `/users/:id`               | admin (часткове оновлення)     |
 | PATCH | `/users/:id/block`         | admin                          |
 | PATCH | `/users/:id/role`          | admin                          |
+
+`GET /users` повертає стандартний `PaginatedDto<UserDto>`. Дозволені розміри сторінки — від 1 до 100; frontend пропонує 10, 25 або 50 записів. Пошук обмежено 100 символами, він нечутливий до регістру та підтримує до трьох частин ПІБ у довільному порядку.
 
 ---
 
@@ -256,6 +260,10 @@
 повноцінну адміністративну UI для створення, редагування, видалення, скасування,
 перенесення, замін, шаблонів та масового скасування.
 
+> **Погоджений напрямок:** офіційний основний і сесійний розклад має надходити
+> з API МАУП. Локальний ScheduleModule залишається описом поточної реалізації до
+> авторизованої перевірки зовнішнього контракту та окремого плану переходу.
+
 ---
 
 ### 4.4 CoursesModule
@@ -263,6 +271,11 @@
 **Файли:** `src/courses/`
 
 **Відповідальність:** дисципліни, матеріали, завдання, здачі, оцінки та електронний журнал занять у межах порталу. Викладач бачить закріплені дисципліни, студентів групи, веде теми занять, відвідування та поточні оцінки. Матеріали й завдання можуть містити файли, критерії оцінювання та безпечні HTTPS-посилання на Moodle, Google Classroom, силабуси, робочі програми або інші зовнішні навчальні ресурси без дублювання повноцінної LMS усередині порталу.
+
+> **Погоджений напрямок:** на поточному етапі студентський навчальний контур має
+> використовувати зовнішні посилання на Moodle, а офіційні оцінки — API МАУП.
+> Видалення або приховування локальних workflow буде окремою зміною після
+> затвердження міграційного сценарію; цей розділ документує наявний код.
 
 **Ендпоінти та доступ:**
 
@@ -758,6 +771,41 @@ interface AuditLogEntry {
 MongoDB E2E quality gate:
 `npm run test:e2e:db -- reports.e2e-spec.ts`.
 
+### 4.11 FilesModule
+
+**Файли:** `src/files/`
+
+**Поточний стан:** авторизоване завантаження й завантаження файлів із
+перевіркою ownership/scope, випадковими storage names, обмеженням розміру та
+allow-list розширень і declared MIME. Файли зберігаються на приватному
+локальному volume і віддаються через контрольований backend endpoint.
+
+**Production gap:** content inspection ще не реалізовано. Перед production
+потрібні quarantine, magic-byte/container validation, antivirus scanning і
+private object storage із контрольованою видачею файлів.
+
+### 4.12 DatabaseMigrationsModule
+
+**Файли:** `src/database-migrations/`
+
+Автоматичні MongoDB migrations використовують версійний ledger, checksum,
+distributed lock, heartbeat і fail-closed перевірку невідомих або змінених
+migrations. У production `DB_MIGRATIONS_ENABLED=true` є обов'язковим.
+
+### 4.13 MaupStudentApiModule
+
+**Файли:** `src/integrations/maup-student-api/`
+
+Підготовлено вимкнений за замовчуванням backend-only клієнт студентського API:
+Basic credentials не передаються у browser, доступні timeout, обмежені retry,
+circuit breaker, ліміт відповіді, нормалізація зовнішніх помилок і безпечний
+mapper без копіювання ІПН та фінансових полів до профільної моделі.
+
+Модуль не підключений до користувацьких сценаріїв і не виконує зовнішніх
+запитів, доки `MAUP_API_ENABLED=false`. URL та credentials не зберігаються в
+репозиторії. Умови активації описані в
+[`docs/integrations/maup-student-api.md`](docs/integrations/maup-student-api.md).
+
 ---
 
 ## 5. Компоненти фронтенду
@@ -833,7 +881,7 @@ src/
 | Опитування | participate | participate | — | manage own | results | results | manage |
 | Вибіркові дисципліни | select | — | manage scoped | manage | — | — | manage |
 | Аналітичні звіти | — | — | scoped | scoped | global | global | global |
-| Користувачі | — | — | scoped search | scoped search | — | student read-only | manage |
+| Користувачі | — | — | scoped search | scoped search | global read-only | global read-only | manage |
 | Аудит | — | — | — | — | — | — | read/export |
 | Довідники | scoped read | scoped read | scoped read | scoped read | read | read | manage |
 
@@ -1009,9 +1057,9 @@ AuditLogEntry
 
 | Метод | Шлях                       | Доступ                         |
 | ----- | -------------------------- | ------------------------------ |
-| GET   | `/users`                   | admin; president — лише студенти, read-only |
-| GET   | `/users/search?q=&role=`   | admin+                         |
-| GET   | `/users/:id`               | admin, president (лише студент), dean |
+| GET   | `/users?page=&limit=&role=&search=` | admin, rector, president; paginated read-only для rector/president |
+| GET   | `/users/search?q=&role=`   | admin, rector, president, dean, department_head |
+| GET   | `/users/:id`               | admin, rector, president, dean |
 | POST  | `/users`                   | admin                          |
 | PATCH | `/users/:id`               | admin                          |
 | PATCH | `/users/:id/block`         | admin                          |
@@ -1132,9 +1180,9 @@ MongoDB разом із причиною, actor-метаданими та ост
 ### Матриця можливостей
 
 Повна матриця можливостей підтримується в `docs/RBAC_MATRIX.md`. Критичні
-інваріанти: лише `admin` змінює користувачів і розклад; `rector` не має
-операційних mutation permissions; `president` отримує лише read-only пошук
-студентів; управлінські ролі бачать звіти у своєму scope.
+інваріанти: лише `admin` змінює користувачів і розклад; `rector` та
+`president` не мають операційних mutation permissions, але отримують глобальний
+read-only каталог користувачів; управлінські ролі бачать звіти у своєму scope.
 
 ---
 
@@ -1218,10 +1266,10 @@ MongoDB разом із причиною, actor-метаданими та ост
 | 7   | CoursesModule і викладацько-студентський контур          | ✅ Реалізовано                              |
 | 8   | ReferencesModule                                        | ✅ CRUD, admin UI, integrity, import/export |
 | 9   | NotificationsModule                                     | ✅ In-app сценарії реалізовано              |
-| 10  | UsersModule                                             | ✅ Реалізовано                              |
+| 10  | UsersModule                                             | ✅ Paginated каталог, multi-part пошук, admin mutations, rector/president read-only |
 | 11  | React auth flow (Zustand, cookies, interceptors)         | ✅ Реалізовано                              |
 | 12  | React layout, lazy routes, RBAC navigation, i18n         | ✅ Реалізовано                              |
-| 13  | Role-based frontend pages                               | ✅ 18 page components                       |
+| 13  | Role-based frontend pages                               | ✅ 20 page components                       |
 | 14  | Docker Compose + MongoDB replica set                    | ✅ Реалізовано                              |
 
 ### Фаза 2 — База даних + File Upload + Опитування
@@ -1260,6 +1308,7 @@ MongoDB разом із причиною, actor-метаданими та ост
 | 7   | i18n (українська + англійська)                              | ✅ Реалізовано                              |
 | 8   | Production email delivery для password reset                | ✅ Authenticated SMTP + production env validation           |
 | 9   | Antivirus/content scanning і private object storage файлів  | ⏳ Наступний етап                           |
+| 10  | Backend-каркас студентського API МАУП                      | ✅ Підготовлено й вимкнено; активація після contract check |
 
 ---
 
@@ -1434,6 +1483,20 @@ online_campus/
 │       │   ├── reports-analytics.service.spec.ts
 │       │   └── reports-exporter.spec.ts
 │       │
+│       ├── database-migrations/ # versioned MongoDB migrations and distributed lock
+│       │   ├── database-migrations.module.ts
+│       │   ├── database-migrations.service.ts
+│       │   ├── database-migrations.registry.ts
+│       │   └── database-migration.types.ts
+│       │
+│       ├── integrations/
+│       │   └── maup-student-api/ # disabled backend-only MAUP API client
+│       │       ├── maup-student-api.module.ts
+│       │       ├── maup-student-api.client.ts
+│       │       ├── maup-student-api.mapper.ts
+│       │       ├── maup-student-api.error.ts
+│       │       └── maup-student-api.types.ts
+│       │
 │       ├── seed-data/         # optional demo data seeders for local fixtures
 │       │   ├── seed.module.ts
 │       │   ├── seed.service.ts
@@ -1607,6 +1670,20 @@ SMTP_SECURE=false
 SMTP_USER=campus
 SMTP_PASSWORD=provider-app-password
 SMTP_CONNECTION_TIMEOUT_MS=10000
+
+# MAUP student API (backend only; disabled until authenticated contract check)
+MAUP_API_ENABLED=false
+MAUP_API_BASE_URL=
+MAUP_API_ALLOWED_HOST=
+MAUP_API_REQUEST_METHOD=POST
+MAUP_API_USERNAME=
+MAUP_API_PASSWORD=
+MAUP_API_TIMEOUT_MS=10000
+MAUP_API_RETRY_ATTEMPTS=2
+MAUP_API_CIRCUIT_FAILURE_THRESHOLD=5
+MAUP_API_CIRCUIT_RESET_TIMEOUT_MS=30000
+MAUP_API_MAX_RESPONSE_BYTES=5000000
+
 SWAGGER_ENABLED=false
 
 # MongoDB
@@ -1669,6 +1746,12 @@ Demo seeders копіюють fixture-дані з `server/src/common/mock-data` 
 `SEED_DEMO_DATA=false` і створюйте реальних адміністраторів контрольованою
 процедурою.
 
+Поки інтеграція з API МАУП вимкнена, `MAUP_API_*` не потрібно додавати ані до
+GitHub Secrets, ані до `.env` на Hetzner. Перед активацією потрібно окремо
+перевірити автентифікований контракт, додати передачу змінних у deploy workflow
+та безпечно налаштувати URL, allow-listed host і credentials у цільовому
+середовищі. Реальний endpoint і credentials у репозиторії не зберігаються.
+
 У локальному `docker-compose.yml` MongoDB доступна backend-контейнеру через
 внутрішню Docker network (`mongodb:27017`) і не публікується на host-порт за
 замовчуванням. Це прибирає конфлікти з локально встановленою MongoDB або іншими
@@ -1676,25 +1759,17 @@ Demo seeders копіюють fixture-дані з `server/src/common/mock-data` 
 
 ### Production (VPS)
 
-Для 5000 користувачів достатньо одного сервера. Рекомендована конфігурація:
+Поточне розгортання використовує репозиторний `docker-compose.yml`: один
+backend-контейнер NestJS, один frontend-контейнер Nginx, MongoDB single-node
+replica set та одноразовий `mongodb-init`. Окремого
+`docker-compose.prod.yml` у проєкті немає.
 
-**Hetzner CX31** (або аналог): 4 vCPU, 8 GB RAM, 80 GB SSD — ~€12/міс.
-
-На сервері запускається `docker-compose.prod.yml`:
-
-```yaml
-services:
-  server: # NestJS — 2 replicas (через docker compose scale або Traefik)
-  client: # Nginx + React build
-  mongo: # MongoDB 7
-  # Traefik або Nginx як reverse proxy з SSL (Let's Encrypt)
-```
-
-**Орієнтовна ємність при 5000 юзерів:**
-
-- Пікове одночасне навантаження ~500 активних сесій
-- NestJS на Node.js легко тримає 1000+ req/s на CX31
-- MongoDB з індексами — без проблем для такого обсягу
+Розмір VPS і допустиме навантаження ще не підтверджені benchmark або load test,
+тому конфігурацію Hetzner потрібно обирати за результатами вимірювань на
+production-like даних. Горизонтальне масштабування backend також потребує
+винесення локального file storage у private object storage або інше спільне
+сховище. Reverse proxy, TLS, backup/restore і monitoring мають бути частиною
+окремого production runbook.
 
 ---
 
@@ -1788,7 +1863,8 @@ CI окремо запускає `academic-access.e2e-spec.ts`, який бло�
 Запускається після push у `master`. Workflow підключається до VPS через SSH, виконує `git pull origin master`, записує `.env` із GitHub Secrets і запускає `docker compose up --build -d`.
 
 Deploy workflow передає обов'язкові `MONGO_*`, `JWT_SECRET`, `PORT`,
-`CLIENT_URL`, `AUTH_CSRF_SECRET` та optional `AUTH_*`/`AUDIT_*` secrets.
+`CLIENT_URL`, `AUTH_CSRF_SECRET` та optional `AUTH_*`, `AUDIT_*`, SMTP і
+database migration settings.
 `MONGO_REPLICA_SET_KEY` є обов'язковим і має бути окремим випадковим секретом
 для кожного середовища. Порожні optional secrets не записуються в `.env`,
 тому застосунок використовує кодові defaults; `AUTH_COOKIE_SECURE` та
@@ -1796,30 +1872,9 @@ Deploy workflow передає обов'язкові `MONGO_*`, `JWT_SECRET`, `P
 `true`. `DEPLOYMENT_ENV` за замовчуванням дорівнює `production`; SMTP secrets
 вимагаються лише коли `PASSWORD_RESET_EMAIL_ENABLED=true`.
 
-```yaml
-name: Deploy
-
-on:
-  push:
-    branches: [master]
-
-jobs:
-  deploy:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Deploy to server
-        uses: appleboy/ssh-action@v1
-        with:
-          host: ${{ secrets.SSH_HOST }}
-          username: ${{ secrets.SSH_USER }}
-          password: ${{ secrets.SSH_PASSWORD }}
-          port: ${{ secrets.SSH_PORT }}
-          script: |
-            cd /opt/online_campus
-            git pull origin master
-            docker compose up --build -d
-            docker image prune -f
-```
+Повна логіка sanitization, required/optional values і defaults підтримується в
+[`.github/workflows/deploy.yml`](.github/workflows/deploy.yml). README навмисно
+не дублює workflow, щоб документація не розходилася з кодом розгортання.
 
 ### Secrets для GitHub Actions
 
@@ -1836,7 +1891,6 @@ jobs:
 | `MONGO_PORT` | порт MongoDB |
 | `MONGO_REPLICA_SET_NAME` | optional; назва replica set (`rs0` за замовчуванням) |
 | `MONGO_REPLICA_SET_KEY` | обов'язковий keyfile secret; згенерувати `openssl rand -hex 48` |
-| `MONGODB_URI` | optional alternative до окремих `MONGO_*`; у production має містити credentials, database name і replica set для transactional outbox |
 | `JWT_SECRET` | секрет для JWT |
 | `PORT` | порт backend |
 | `CLIENT_URL` | URL frontend для CORS і reset links |
@@ -1861,13 +1915,21 @@ jobs:
 | `SMTP_SECURE` | optional; `true` для SMTPS/465, інакше `false` |
 | `SMTP_USER` | обов'язковий у production, коли SMTP увімкнений |
 | `SMTP_PASSWORD` | обов'язковий у production, коли SMTP увімкнений |
+| `SMTP_CONNECTION_TIMEOUT_MS` | optional; timeout SMTP connection (`10000` за замовчуванням) |
 | `AUDIT_TRANSACTIONAL_OUTBOX` | `true` для атомарного доменного запису та аудиту |
 | `AUDIT_OUTBOX_POLL_INTERVAL_MS` | optional; інтервал доставки audit-подій |
 | `AUDIT_OUTBOX_LOCK_TIMEOUT_MS` | optional; timeout відновлення завислого worker lock |
 | `AUDIT_OUTBOX_MAX_ATTEMPTS` | optional; кількість спроб до dead-letter state |
+| `DB_MIGRATIONS_ENABLED` | optional; deploy default `true`, у production має залишатися `true` |
+| `DB_MIGRATION_LOCK_TTL_MS` | optional; TTL distributed migration lock (`300000` за замовчуванням) |
+| `DB_MIGRATION_WAIT_TIMEOUT_MS` | optional; максимальне очікування migration lock (`60000`) |
+| `DB_MIGRATION_POLL_INTERVAL_MS` | optional; інтервал перевірки migration lock (`1000`) |
 | `SWAGGER_ENABLED` | `true` для dev, `false`/unset у production; Swagger вимкнений у production за замовчуванням |
-| `SEED_DEMO_DATA` | optional; `true` тільки для локальних fixture-даних, `false`/unset для shared dev/prod |
-| `SEED_DEMO_DATA_IN_PRODUCTION` | emergency/demo-only override; не додавати у production secrets |
+
+`SEED_DEMO_DATA` і `SEED_DEMO_DATA_IN_PRODUCTION` не є GitHub Secrets:
+workflow завжди записує для них `false`. `MONGODB_URI` також не передається
+поточним workflow, який формує підключення з окремих `MONGO_*` значень.
+`MAUP_API_*` не налаштовуються до окремого рішення про активацію інтеграції.
 
 `ConfigModule` застосовує централізовану fail-fast схему. Для
 `NODE_ENV=production` застосунок не запуститься зі слабкими або placeholder

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -256,6 +256,7 @@ export default function App() {
               <ProtectedRoute
                 allowedRoles={[
                   Role.ADMIN,
+                  Role.RECTOR,
                   Role.PRESIDENT,
                 ]}>
                 <LazyPage>

--- a/client/src/components/Layout.tsx
+++ b/client/src/components/Layout.tsx
@@ -75,7 +75,7 @@ const NAV_ITEMS: {
   {
     labelKey: 'nav.users',
     path: '/users',
-    roles: [Role.ADMIN, Role.PRESIDENT],
+    roles: [Role.ADMIN, Role.RECTOR, Role.PRESIDENT],
   },
   {
     labelKey: 'nav.auditLog',

--- a/client/src/i18n.ts
+++ b/client/src/i18n.ts
@@ -525,8 +525,17 @@ const resources = {
       'users.searchPlaceholder': 'Пошук за ПІБ...',
       'users.searchButton': 'Знайти',
       'users.allRoles': 'Усі ролі',
-      'users.readOnlyStudentDirectory':
-        'Режим перегляду: доступний лише пошук студентів без редагування, зміни ролей або блокування.',
+      'users.readOnlyDirectory':
+        'Режим перегляду: редагування, зміна ролей і блокування користувачів недоступні.',
+      'users.loading': 'Завантаження користувачів...',
+      'users.empty': 'Користувачів не знайдено',
+      'users.loadError': 'Не вдалося завантажити користувачів',
+      'users.actionError': 'Не вдалося змінити статус користувача',
+      'users.perPage': 'На сторінці',
+      'users.pageInfo':
+        'Сторінка {{page}} з {{total}} · Усього користувачів: {{count}}',
+      'users.previous': 'Назад',
+      'users.next': 'Далі',
       'users.fullName': 'ПІБ',
       'users.role': 'Роль',
       'users.email': 'Email',
@@ -1537,8 +1546,17 @@ const resources = {
       'users.searchPlaceholder': 'Search by full name...',
       'users.searchButton': 'Search',
       'users.allRoles': 'All roles',
-      'users.readOnlyStudentDirectory':
-        'Read-only mode: only student lookup is available; editing, role changes, and blocking are disabled.',
+      'users.readOnlyDirectory':
+        'Read-only mode: editing, role changes, and blocking are disabled.',
+      'users.loading': 'Loading users...',
+      'users.empty': 'No users found',
+      'users.loadError': 'Could not load users',
+      'users.actionError': 'Could not change the user status',
+      'users.perPage': 'Per page',
+      'users.pageInfo':
+        'Page {{page}} of {{total}} · Total users: {{count}}',
+      'users.previous': 'Previous',
+      'users.next': 'Next',
       'users.fullName': 'Full name',
       'users.role': 'Role',
       'users.email': 'Email',

--- a/client/src/pages/admin/UsersPage.tsx
+++ b/client/src/pages/admin/UsersPage.tsx
@@ -1,15 +1,34 @@
+import { ChevronLeft, ChevronRight, LoaderCircle } from 'lucide-react';
 import { useEffect, useState } from 'react';
-import api from '../../services/api';
-import type { User } from '../../types';
-import { Role, ROLE_LABEL_KEYS } from '../../types';
 import { useTranslation } from 'react-i18next';
 import CreateUserModal from '../../components/CreateUserModal';
+import api from '../../services/api';
 import { useAuthStore } from '../../store/authStore';
+import type { PaginatedResponse, User } from '../../types';
+import { Role, ROLE_LABEL_KEYS } from '../../types';
+
+const PAGE_SIZE_OPTIONS = [10, 25, 50] as const;
+
+const EMPTY_PAGE: PaginatedResponse<User> = {
+  docs: [],
+  totalDocs: 0,
+  limit: PAGE_SIZE_OPTIONS[0],
+  page: 1,
+  totalPages: 0,
+  hasNextPage: false,
+  hasPrevPage: false,
+};
 
 export default function UsersPage() {
-  const [users, setUsers] = useState<User[]>([]);
+  const [usersPage, setUsersPage] =
+    useState<PaginatedResponse<User>>(EMPTY_PAGE);
   const [search, setSearch] = useState('');
-  const [roleFilter, setRoleFilter] = useState<string>('');
+  const [appliedSearch, setAppliedSearch] = useState('');
+  const [roleFilter, setRoleFilter] = useState<Role | ''>('');
+  const [page, setPage] = useState(1);
+  const [limit, setLimit] = useState<number>(PAGE_SIZE_OPTIONS[0]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
   const [editingUser, setEditingUser] = useState<User | null>(null);
   const [refreshKey, setRefreshKey] = useState(0);
@@ -17,50 +36,84 @@ export default function UsersPage() {
   const canManageUsers = currentUser?.role === Role.ADMIN;
   const { t } = useTranslation();
 
+  useEffect(() => {
+    const controller = new AbortController();
+    let active = true;
+
+    void api
+      .get<PaginatedResponse<User>>('/users', {
+        params: {
+          page,
+          limit,
+          role: roleFilter || undefined,
+          search: appliedSearch || undefined,
+        },
+        signal: controller.signal,
+      })
+      .then(({ data }) => {
+        if (!active) return;
+
+        if (data.totalPages > 0 && page > data.totalPages) {
+          setLoading(true);
+          setPage(data.totalPages);
+          return;
+        }
+        setUsersPage(data);
+      })
+      .catch(() => {
+        if (active && !controller.signal.aborted) {
+          setUsersPage(EMPTY_PAGE);
+          setError(t('users.loadError'));
+        }
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+
+    return () => {
+      active = false;
+      controller.abort();
+    };
+  }, [appliedSearch, limit, page, refreshKey, roleFilter, t]);
+
   const handleToggleBlock = async (user: User) => {
     try {
-      const { data: updated } = await api.patch(`/users/${user.id}/block`);
-      setUsers((prev) => prev.map((u) => (u.id === user.id ? { ...u, status: updated.status } : u)));
-    } catch {
-      // error
-    }
-  };
-
-  useEffect(() => {
-    const params = new URLSearchParams();
-    if (roleFilter) params.set('role', roleFilter);
-
-    api
-      .get(`/users?${params}`)
-      .then(({ data }) => {
-        const fetchedUsers = Array.isArray(data) ? data : data.docs || [];
-        setUsers(fetchedUsers);
-      })
-      .catch(() => {});
-  }, [roleFilter, refreshKey]);
-
-  const handleSearch = async () => {
-    if (!search.trim()) return;
-    try {
-      const { data } = await api.get(
-        `/users/search?q=${encodeURIComponent(search)}`,
+      const { data: updated } = await api.patch<User>(
+        `/users/${user.id}/block`,
       );
-      setUsers(data);
+      setUsersPage((current) => ({
+        ...current,
+        docs: current.docs.map((item) =>
+          item.id === user.id ? { ...item, status: updated.status } : item,
+        ),
+      }));
     } catch {
-      // error
+      setError(t('users.actionError'));
     }
   };
+
+  const handleSearch = () => {
+    setLoading(true);
+    setError(null);
+    setPage(1);
+    setAppliedSearch(search.trim());
+    if (search.trim() === appliedSearch) {
+      setRefreshKey((current) => current + 1);
+    }
+  };
+
+  const currentPage = usersPage.totalPages === 0 ? 0 : usersPage.page;
+  const totalPages = usersPage.totalPages;
 
   return (
     <div>
-      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-6">
-        <h1 className="text-2xl font-bold text-gray-900">
-          {t('users.title')}
-        </h1>
+      <div className="mb-6 flex flex-col justify-between gap-4 sm:flex-row sm:items-center">
+        <h1 className="text-2xl font-bold text-gray-900">{t('users.title')}</h1>
         {canManageUsers && (
           <button
+            type="button"
             onClick={() => setIsCreateModalOpen(true)}
-            className="px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-700 transition-colors whitespace-nowrap"
+            className="whitespace-nowrap rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700"
           >
             {t('users.addUser')}
           </button>
@@ -69,65 +122,98 @@ export default function UsersPage() {
 
       {!canManageUsers && (
         <div className="mb-6 rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-800">
-          {t('users.readOnlyStudentDirectory')}
+          {t('users.readOnlyDirectory')}
         </div>
       )}
 
-      {/* Filters */}
-      <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-4 mb-6">
-        <div className="flex flex-col gap-3 sm:flex-row">
-          <div className="flex flex-col gap-2 flex-1 sm:flex-row">
+      <div className="mb-6 rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
+        <div className="flex flex-col gap-3 lg:flex-row">
+          <div className="flex flex-1 flex-col gap-2 sm:flex-row">
             <input
-              type="text"
+              type="search"
               value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              onKeyDown={(e) => e.key === 'Enter' && handleSearch()}
+              onChange={(event) => setSearch(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter') handleSearch();
+              }}
               placeholder={t('users.searchPlaceholder')}
-              className="w-full sm:flex-1 px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 outline-none"
+              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-blue-500 sm:flex-1"
             />
 
             <button
+              type="button"
               onClick={handleSearch}
-              className="w-full sm:w-auto px-4 py-2 bg-blue-600 text-white rounded-lg text-sm hover:bg-blue-700">
+              className="w-full rounded-lg bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700 sm:w-auto"
+            >
               {t('users.searchButton')}
             </button>
           </div>
 
-          {canManageUsers && (
+          <select
+            value={roleFilter}
+            onChange={(event) => {
+              setLoading(true);
+              setError(null);
+              setRoleFilter(event.target.value as Role | '');
+              setPage(1);
+            }}
+            className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-blue-500 lg:w-auto"
+            aria-label={t('users.role')}
+          >
+            <option value="">{t('users.allRoles')}</option>
+            {Object.values(Role).map((role) => (
+              <option key={role} value={role}>
+                {t(ROLE_LABEL_KEYS[role])}
+              </option>
+            ))}
+          </select>
+
+          <label className="flex items-center gap-2 text-sm text-gray-600">
+            <span className="whitespace-nowrap">{t('users.perPage')}</span>
             <select
-              value={roleFilter}
-              onChange={(e) => setRoleFilter(e.target.value)}
-              className="w-full sm:w-auto px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 outline-none">
-              <option value="">{t('users.allRoles')}</option>
-              {Object.values(Role).map((role) => (
-                <option key={role} value={role}>
-                  {t(ROLE_LABEL_KEYS[role])}
+              value={limit}
+              onChange={(event) => {
+                setLoading(true);
+                setError(null);
+                setLimit(Number(event.target.value));
+                setPage(1);
+              }}
+              className="rounded-lg border border-gray-300 px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              {PAGE_SIZE_OPTIONS.map((option) => (
+                <option key={option} value={option}>
+                  {option}
                 </option>
               ))}
             </select>
-          )}
+          </label>
         </div>
       </div>
 
-      {/* Users Table */}
+      {error && (
+        <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {error}
+        </div>
+      )}
+
       <div className="overflow-x-auto rounded-xl border border-gray-200 bg-white shadow-sm">
-        <table className="min-w-[700px] w-full">
-          <thead className="bg-gray-50 border-b">
+        <table className="w-full min-w-[700px]">
+          <thead className="border-b bg-gray-50">
             <tr>
-              <th className="p-4 text-left text-xs font-semibold text-gray-500 uppercase">
+              <th className="p-4 text-left text-xs font-semibold uppercase text-gray-500">
                 {t('users.fullName')}
               </th>
-              <th className="p-4 text-left text-xs font-semibold text-gray-500 uppercase">
+              <th className="p-4 text-left text-xs font-semibold uppercase text-gray-500">
                 {t('users.role')}
               </th>
-              <th className="p-4 text-left text-xs font-semibold text-gray-500 uppercase">
+              <th className="p-4 text-left text-xs font-semibold uppercase text-gray-500">
                 {t('users.email')}
               </th>
-              <th className="p-4 text-left text-xs font-semibold text-gray-500 uppercase">
+              <th className="p-4 text-left text-xs font-semibold uppercase text-gray-500">
                 {t('users.status')}
               </th>
               {canManageUsers && (
-                <th className="p-4 text-left text-xs font-semibold text-gray-500 uppercase">
+                <th className="p-4 text-left text-xs font-semibold uppercase text-gray-500">
                   {t('users.actions')}
                 </th>
               )}
@@ -135,10 +221,11 @@ export default function UsersPage() {
           </thead>
 
           <tbody>
-            {users.map((user) => (
+            {usersPage.docs.map((user) => (
               <tr
                 key={user.id}
-                className="border-b last:border-0 hover:bg-gray-50">
+                className="border-b last:border-0 hover:bg-gray-50"
+              >
                 <td className="p-4">
                   <div className="font-medium text-gray-900">
                     {user.lastName} {user.firstName} {user.middleName || ''}
@@ -146,7 +233,7 @@ export default function UsersPage() {
                 </td>
 
                 <td className="p-4">
-                  <span className="text-xs bg-blue-100 text-blue-700 px-2 py-1 rounded">
+                  <span className="rounded bg-blue-100 px-2 py-1 text-xs text-blue-700">
                     {t(ROLE_LABEL_KEYS[user.role])}
                   </span>
                 </td>
@@ -155,11 +242,12 @@ export default function UsersPage() {
 
                 <td className="p-4">
                   <span
-                    className={`text-xs px-2 py-1 rounded ${
+                    className={`rounded px-2 py-1 text-xs ${
                       user.status === 'active'
                         ? 'bg-green-100 text-green-700'
                         : 'bg-red-100 text-red-700'
-                    }`}>
+                    }`}
+                  >
                     {user.status === 'active'
                       ? t('users.statusActive')
                       : t('users.statusBlocked')}
@@ -169,44 +257,147 @@ export default function UsersPage() {
                 {canManageUsers && (
                   <td className="p-4">
                     <div className="flex items-center gap-2">
-                    <button
-                      onClick={() => {
-                        setEditingUser(user);
-                        setIsCreateModalOpen(true);
-                      }}
-                      className="text-blue-600 hover:text-blue-800 transition-colors"
-                      title={t('users.edit')}
-                    >
-                      <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-                      </svg>
-                    </button>
-                    <button
-                      onClick={() => handleToggleBlock(user)}
-                      className={`transition-colors ${
-                        user.status === 'active'
-                          ? 'text-red-500 hover:text-red-700'
-                          : 'text-green-600 hover:text-green-800'
-                      }`}
-                      title={user.status === 'active' ? t('users.block') : t('users.unblock')}
-                    >
-                      {user.status === 'active' ? (
-                        <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setEditingUser(user);
+                          setIsCreateModalOpen(true);
+                        }}
+                        className="text-blue-600 transition-colors hover:text-blue-800"
+                        title={t('users.edit')}
+                      >
+                        <svg
+                          className="h-5 w-5"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke="currentColor"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={2}
+                            d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
+                          />
                         </svg>
-                      ) : (
-                        <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 11V7a4 4 0 118 0m-4 8v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2z" />
-                        </svg>
-                      )}
-                    </button>
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => void handleToggleBlock(user)}
+                        className={`transition-colors ${
+                          user.status === 'active'
+                            ? 'text-red-500 hover:text-red-700'
+                            : 'text-green-600 hover:text-green-800'
+                        }`}
+                        title={
+                          user.status === 'active'
+                            ? t('users.block')
+                            : t('users.unblock')
+                        }
+                      >
+                        {user.status === 'active' ? (
+                          <svg
+                            className="h-5 w-5"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            stroke="currentColor"
+                          >
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              strokeWidth={2}
+                              d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"
+                            />
+                          </svg>
+                        ) : (
+                          <svg
+                            className="h-5 w-5"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            stroke="currentColor"
+                          >
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              strokeWidth={2}
+                              d="M8 11V7a4 4 0 118 0m-4 8v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2z"
+                            />
+                          </svg>
+                        )}
+                      </button>
                     </div>
                   </td>
                 )}
               </tr>
             ))}
+
+            {loading && usersPage.docs.length === 0 && (
+              <tr>
+                <td
+                  colSpan={canManageUsers ? 5 : 4}
+                  className="p-10 text-center text-sm text-gray-500"
+                >
+                  <span className="inline-flex items-center gap-2">
+                    <LoaderCircle
+                      className="h-4 w-4 animate-spin"
+                      aria-hidden="true"
+                    />
+                    {t('users.loading')}
+                  </span>
+                </td>
+              </tr>
+            )}
+
+            {!loading && usersPage.docs.length === 0 && (
+              <tr>
+                <td
+                  colSpan={canManageUsers ? 5 : 4}
+                  className="p-10 text-center text-sm text-gray-500"
+                >
+                  {t('users.empty')}
+                </td>
+              </tr>
+            )}
           </tbody>
         </table>
+      </div>
+
+      <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="text-sm text-gray-600">
+          {t('users.pageInfo', {
+            page: currentPage,
+            total: totalPages,
+            count: usersPage.totalDocs,
+          })}
+        </div>
+
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => {
+              setLoading(true);
+              setError(null);
+              setPage((current) => Math.max(1, current - 1));
+            }}
+            disabled={!usersPage.hasPrevPage || loading}
+            className="inline-flex items-center gap-2 rounded-lg border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:border-gray-200 disabled:text-gray-300"
+          >
+            <ChevronLeft className="h-4 w-4" aria-hidden="true" />
+            {t('users.previous')}
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              setLoading(true);
+              setError(null);
+              setPage((current) => current + 1);
+            }}
+            disabled={!usersPage.hasNextPage || loading}
+            className="inline-flex items-center gap-2 rounded-lg border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:border-gray-200 disabled:text-gray-300"
+          >
+            {t('users.next')}
+            <ChevronRight className="h-4 w-4" aria-hidden="true" />
+          </button>
+        </div>
       </div>
 
       {canManageUsers && (
@@ -218,7 +409,11 @@ export default function UsersPage() {
             setIsCreateModalOpen(false);
             setEditingUser(null);
           }}
-          onSuccess={() => setRefreshKey((prev) => prev + 1)}
+          onSuccess={() => {
+            setLoading(true);
+            setError(null);
+            setRefreshKey((current) => current + 1);
+          }}
         />
       )}
     </div>

--- a/server/src/auth/rbac-regression.spec.ts
+++ b/server/src/auth/rbac-regression.spec.ts
@@ -76,4 +76,21 @@ describe('critical RBAC regression policy', () => {
       }
     },
   );
+
+  it('grants rector and president user-directory reads without mutations', () => {
+    const directoryRoles = rolesFor(
+      controllerMethod(UsersController.prototype, 'findAll'),
+    );
+    const detailRoles = rolesFor(
+      controllerMethod(UsersController.prototype, 'findOne'),
+    );
+
+    expect(directoryRoles).toEqual([Role.ADMIN, Role.RECTOR, Role.PRESIDENT]);
+    expect(detailRoles).toEqual([
+      Role.ADMIN,
+      Role.RECTOR,
+      Role.PRESIDENT,
+      Role.DEAN,
+    ]);
+  });
 });

--- a/server/src/common/access/academic-access.service.spec.ts
+++ b/server/src/common/access/academic-access.service.spec.ts
@@ -50,6 +50,19 @@ describe('AcademicAccessService', () => {
     );
   });
 
+  it.each([Role.ADMIN, Role.RECTOR, Role.PRESIDENT])(
+    'grants %s a global read-only user scope',
+    async (role) => {
+      await expect(
+        service.buildVisibleUserFilter({
+          sub: new Types.ObjectId().toHexString(),
+          login: role,
+          role,
+        }),
+      ).resolves.toEqual({});
+    },
+  );
+
   it('limits students to standard courses and explicitly enrolled electives', async () => {
     userModel.findById.mockReturnValue(
       query({ studentProfile: { group: groupId } }),

--- a/server/src/common/access/academic-access.service.ts
+++ b/server/src/common/access/academic-access.service.ts
@@ -22,7 +22,11 @@ const GLOBAL_ACADEMIC_READ_ROLES = new Set<Role>([
   Role.PRESIDENT,
 ]);
 
-const GLOBAL_USER_READ_ROLES = new Set<Role>([Role.ADMIN, Role.PRESIDENT]);
+const GLOBAL_USER_READ_ROLES = new Set<Role>([
+  Role.ADMIN,
+  Role.RECTOR,
+  Role.PRESIDENT,
+]);
 
 @Injectable()
 export class AcademicAccessService {

--- a/server/src/users/dto/user-query.dto.ts
+++ b/server/src/users/dto/user-query.dto.ts
@@ -1,4 +1,4 @@
-import { IsOptional, IsEnum } from 'class-validator';
+import { IsOptional, IsEnum, IsString, MaxLength } from 'class-validator';
 import { Role } from '../../common/types/roles.enum';
 import { PaginationDto } from '../../common/dto/pagination.dto';
 import { ApiPropertyOptional } from '@nestjs/swagger';
@@ -8,4 +8,13 @@ export class UserQueryDto extends PaginationDto {
   @IsOptional()
   @IsEnum(Role)
   role?: Role;
+
+  @ApiPropertyOptional({
+    description: 'Case-insensitive search by one or more name parts',
+    maxLength: 100,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  search?: string;
 }

--- a/server/src/users/users.controller.ts
+++ b/server/src/users/users.controller.ts
@@ -98,18 +98,24 @@ export class UsersController {
   }
 
   @Get()
-  @Roles(Role.ADMIN, Role.PRESIDENT)
+  @Roles(Role.ADMIN, Role.RECTOR, Role.PRESIDENT)
   @ApiPaginatedResponse(UserDto)
   findAll(
     @Query() query: UserQueryDto,
     @Req() req: AuthenticatedRequest,
   ): Promise<PaginatedDto<UserDto>> {
-    const { role, ...paginationDto } = query;
-    return this.usersService.findAll(paginationDto, role, req.user);
+    const { role, search, ...paginationDto } = query;
+    return this.usersService.findAll(paginationDto, role, search, req.user);
   }
 
   @Get('search')
-  @Roles(Role.ADMIN, Role.PRESIDENT, Role.DEAN, Role.DEPARTMENT_HEAD)
+  @Roles(
+    Role.ADMIN,
+    Role.RECTOR,
+    Role.PRESIDENT,
+    Role.DEAN,
+    Role.DEPARTMENT_HEAD,
+  )
   search(@Query() query: UserSearchQueryDto, @Req() req: AuthenticatedRequest) {
     return this.usersService.findByName(query.q ?? '', query.role, req.user);
   }
@@ -133,7 +139,7 @@ export class UsersController {
   }
 
   @Get(':id')
-  @Roles(Role.ADMIN, Role.PRESIDENT, Role.DEAN)
+  @Roles(Role.ADMIN, Role.RECTOR, Role.PRESIDENT, Role.DEAN)
   findOne(@Param('id') id: string, @Req() req: AuthenticatedRequest) {
     return this.usersService.findOne(id, req.user);
   }

--- a/server/src/users/users.service.spec.ts
+++ b/server/src/users/users.service.spec.ts
@@ -13,6 +13,7 @@ type ModelMock = {
   findByIdAndUpdate: jest.Mock;
   findOne: jest.Mock;
   countDocuments: jest.Mock;
+  paginate: jest.Mock;
 };
 
 function objectId(): string {
@@ -45,6 +46,11 @@ function userResponse(overrides: Record<string, unknown> = {}) {
 describe('UsersService', () => {
   let service: UsersService;
   let model: ModelMock;
+  let academicAccessService: {
+    buildVisibleUserFilter: jest.Mock;
+    canAccessGroup: jest.Mock;
+    canAccessDepartment: jest.Mock;
+  };
   let removeAllRefreshTokenHashesSpy: jest.SpyInstance;
 
   beforeEach(() => {
@@ -53,19 +59,64 @@ describe('UsersService', () => {
       findByIdAndUpdate: jest.fn(),
       findOne: jest.fn(),
       countDocuments: jest.fn(),
+      paginate: jest.fn(),
     };
 
-    service = new UsersService(
-      model as never,
-      {
-        buildVisibleUserFilter: jest.fn().mockResolvedValue({}),
-        canAccessGroup: jest.fn().mockResolvedValue(true),
-        canAccessDepartment: jest.fn().mockResolvedValue(true),
-      } as never,
-    );
+    academicAccessService = {
+      buildVisibleUserFilter: jest.fn().mockResolvedValue({}),
+      canAccessGroup: jest.fn().mockResolvedValue(true),
+      canAccessDepartment: jest.fn().mockResolvedValue(true),
+    };
+
+    service = new UsersService(model as never, academicAccessService as never);
     removeAllRefreshTokenHashesSpy = jest
       .spyOn(service, 'removeAllRefreshTokenHashes')
       .mockResolvedValue(undefined);
+  });
+
+  it('paginates a role-filtered multi-part name search', async () => {
+    model.paginate.mockResolvedValue({
+      docs: [userResponse({ role: Role.STUDENT })],
+      totalDocs: 31,
+      limit: 25,
+      page: 2,
+      totalPages: 2,
+      hasNextPage: false,
+      hasPrevPage: true,
+      nextPage: null,
+      prevPage: 1,
+    });
+    const requester = {
+      sub: objectId(),
+      login: 'rector',
+      role: Role.RECTOR,
+    };
+
+    const result = await service.findAll(
+      { page: 2, limit: 25 },
+      Role.STUDENT,
+      'Петренко Іван',
+      requester,
+    );
+
+    const [filter, options] = model.paginate.mock.calls[0] as [
+      { $and: Array<Record<string, unknown>> },
+      Record<string, unknown>,
+    ];
+    expect(filter.$and[0]).toEqual({ role: Role.STUDENT });
+    expect(filter.$and).toHaveLength(3);
+    expect(filter.$and[1]).toHaveProperty('$or');
+    expect(filter.$and[2]).toHaveProperty('$or');
+    expect(options).toMatchObject({ page: 2, limit: 25, lean: true });
+    expect(academicAccessService.buildVisibleUserFilter).toHaveBeenCalledWith(
+      requester,
+    );
+    expect(result).toMatchObject({
+      totalDocs: 31,
+      page: 2,
+      totalPages: 2,
+      hasPrevPage: true,
+    });
   });
 
   it('changes a student to teacher, clears the student profile and resets refresh sessions', async () => {

--- a/server/src/users/users.service.ts
+++ b/server/src/users/users.service.ts
@@ -566,12 +566,8 @@ export class UsersService {
     const scopeFilter = requester
       ? await this.academicAccessService.buildVisibleUserFilter(requester)
       : {};
-    const requestedUserFilter =
-      requester?.role === Role.PRESIDENT
-        ? { _id: id, role: Role.STUDENT }
-        : { _id: id };
     const user = await this.userModel
-      .findOne({ $and: [requestedUserFilter, scopeFilter] })
+      .findOne({ $and: [{ _id: id }, scopeFilter] })
       .select('-passwordHash')
       .populate('studentProfile.group')
       .populate({
@@ -590,6 +586,7 @@ export class UsersService {
   async findAll(
     paginationDto: PaginationDto,
     role?: Role,
+    search?: string,
     requester?: AuthenticatedUser,
   ): Promise<PaginatedDto<UserDto>> {
     const { page, limit } = paginationDto;
@@ -599,9 +596,31 @@ export class UsersService {
       sort: { createdAt: -1 },
       lean: true,
     };
-    const effectiveRole =
-      requester?.role === Role.PRESIDENT ? Role.STUDENT : role;
-    const query = effectiveRole ? { role: effectiveRole } : {};
+    const filters: Array<Record<string, unknown>> = [];
+    if (role) {
+      filters.push({ role });
+    }
+
+    for (const token of normalizeSearchTokens(search)) {
+      const pattern = new RegExp(escapeRegex(token), 'i');
+      filters.push({
+        $or: [
+          { firstName: pattern },
+          { lastName: pattern },
+          { middleName: pattern },
+        ],
+      });
+    }
+
+    if (requester) {
+      const scopeFilter =
+        await this.academicAccessService.buildVisibleUserFilter(requester);
+      if (Object.keys(scopeFilter).length > 0) {
+        filters.push(scopeFilter);
+      }
+    }
+
+    const query = filters.length > 0 ? { $and: filters } : {};
     const result = await this.userModel.paginate(query, options);
     return transformToPaginatedDto(UserDto, result);
   }
@@ -619,10 +638,8 @@ export class UsersService {
       $or: [{ firstName: q }, { lastName: q }, { middleName: q }],
     };
 
-    const effectiveRole =
-      requester?.role === Role.PRESIDENT ? Role.STUDENT : role;
-    if (effectiveRole) {
-      searchFilter.role = effectiveRole;
+    if (role) {
+      searchFilter.role = role;
     }
     const scopeFilter = requester
       ? await this.academicAccessService.buildVisibleUserFilter(requester)
@@ -940,4 +957,12 @@ export class UsersService {
       });
     }
   }
+}
+
+function normalizeSearchTokens(value?: string): string[] {
+  if (!value) {
+    return [];
+  }
+
+  return value.trim().split(/\s+/).filter(Boolean).slice(0, 3);
 }

--- a/server/test/identity.e2e-spec.ts
+++ b/server/test/identity.e2e-spec.ts
@@ -224,6 +224,28 @@ describe('Identity and session security (e2e)', () => {
     const rectorCookies = cookieHeader(rectorSession);
     const rectorCsrfToken = cookieValue(rectorSession, 'campus_csrf_token');
 
+    const directory = await request(app.getHttpServer())
+      .get('/api/users?page=1&limit=10&search=Created%20Teacher')
+      .set('Cookie', rectorCookies)
+      .expect(200);
+    const directoryBody = responseBody<{
+      docs: Array<{ id: string; role: Role }>;
+      totalDocs: number;
+      page: number;
+      totalPages: number;
+    }>(directory);
+    expect(directoryBody.docs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: created?._id.toString(),
+          role: Role.TEACHER,
+        }),
+      ]),
+    );
+    expect(directoryBody.totalDocs).toBeGreaterThanOrEqual(1);
+    expect(directoryBody.page).toBe(1);
+    expect(directoryBody.totalPages).toBeGreaterThanOrEqual(1);
+
     await request(app.getHttpServer())
       .patch(`/api/users/${created?._id.toString()}`)
       .set('Cookie', rectorCookies)


### PR DESCRIPTION
<details>
<summary><strong>Українська версія</strong></summary>

## Опис

Цей PR виправляє каталог користувачів: тепер усі користувачі доступні через серверну пагінацію, а не лише перша сторінка, яку повертав backend.

Також застосовано погоджені правила доступу для ректора та президента: обидві ролі можуть переглядати й шукати всіх користувачів, але будь-які зміни залишаються доступними лише адміністратору.

## Зміни

### Backend

- Додано пагінацію каталогу користувачів.
- Додано фільтрацію за роллю в межах пагінації.
- Додано нечутливий до регістру пошук за кількома частинами ПІБ.
- Довжину пошукового запиту обмежено 100 символами.
- Пошукові значення екрануються перед створенням регулярних виразів.
- Ректору та президенту надано глобальний доступ до перегляду користувачів.
- Створення, редагування, зміна ролей і блокування залишилися доступними лише адміністратору.
- Додано RBAC, service, academic-scope та database E2E регресійні тести.

### Frontend

- Додано навігацію між сторінками.
- Додано вибір 10, 25 або 50 користувачів на сторінці.
- Додано відображення поточної сторінки та загальної кількості користувачів.
- Пошук і фільтр ролі інтегровано із серверною пагінацією.
- Додано стани завантаження, відсутності даних і помилки.
- Ректору додано маршрут і пункт навігації каталогу користувачів.
- Дії керування залишилися видимими лише адміністратору.

## Перевірка

- Server lint пройдено.
- Server build пройдено.
- Пройдено 227 unit-тестів.
- Identity database E2E-тести пройдено.
- Client lint пройдено.
- Client production build пройдено.

## Не входить до PR

Цей PR не додає перегляд зовнішнього профілю студента, оцінок, платежів, заборгованості або розкладу МАУП. Для цих розділів потрібен авторизований доступ до API.

</details>

## Summary

This PR fixes the user directory so that all users can be accessed through server-side pagination instead of displaying only the first backend page.

It also applies the approved access rules for the rector and president: both roles can browse and search the complete user directory, while all user mutations remain restricted to administrators.

## Changes

### Backend

- Added paginated user-directory search.
- Added role filtering within pagination.
- Added case-insensitive multi-part full-name search.
- Limited search input to 100 characters.
- Escaped search expressions before creating regular expressions.
- Granted rector and president global read-only user scope.
- Kept user creation, editing, role changes, and blocking restricted to administrators.
- Added RBAC, service, academic-scope, and database E2E regression tests.

### Frontend

- Added page navigation controls.
- Added 10, 25, and 50 users-per-page options.
- Added total user and page information.
- Integrated search and role filtering with server-side pagination.
- Added loading, empty, and error states.
- Added the user directory route and navigation item for the rector.
- Preserved administrator-only management actions.

## Validation

- Server lint passed.
- Server build passed.
- 227 unit tests passed.
- Identity database E2E tests passed.
- Client lint passed.
- Client production build passed.

## Not included

This PR does not implement the external MAUP student profile, marks, payments, balances, or schedule views. Those sections require authenticated API access and will be added separately.