### PR TITLE
feat: add MAUP news RSS feed integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Електронний Кампус МАУП — Технічна документація
 
-> Версія документа: 3.1
+> Версія документа: 3.2
 > Статус: актуальний
 
 ---
@@ -31,7 +31,7 @@
 
 ### Призначення
 
-Система є **самостійним порталом** з власною базою даних і власними критичними процесами: кабінети користувачів, опитування, вибіркові дисципліни, сповіщення, довідники та аудит. Поточна реалізація також містить локальні модулі розкладу, курсів, завдань і оцінок. Погоджений цільовий стан передбачає отримання академічних даних із API МАУП та використання зовнішніх посилань на Moodle замість дублювання LMS-функцій.
+Система є **самостійним порталом** з власною базою даних і власними критичними процесами: кабінети користувачів, опитування, вибіркові дисципліни, сповіщення, новини МАУП, довідники та аудит. Поточна реалізація також містить локальні модулі розкладу, курсів, завдань і оцінок. Погоджений цільовий стан передбачає отримання академічних даних із API МАУП та використання зовнішніх посилань на Moodle замість дублювання LMS-функцій.
 
 ```
 ┌─────────────────────────────────────────────────────────┐
@@ -42,7 +42,7 @@
 ┌─────────────────────────────────────────────────────────┐
 │                    Кампус — єдина система                │
 │  Auth · Users · Schedule · Courses · Surveys            │
-│  Notifications · References · AuditLog                  │
+│  Notifications · News · References · AuditLog           │
 │  Elective disciplines                                   │
 │                 Власна БД (MongoDB)                      │
 └─────────────────────────────────────────────────────────┘
@@ -61,6 +61,7 @@
 - **Система опитувань** — створення, проходження студентами та викладачами, аналіз результатів
 - **Вибіркові дисципліни** — критичний модуль: вибір студентом із запропонованого переліку та фіксація результату в кабінеті
 - Система сповіщень: зміни розкладу, нові завдання, оголошення
+- Новини МАУП з офіційної RSS-стрічки через backend proxy з cache/fallback
 - Відновлення пароля через одноразовий reset token без розкриття існування акаунта
 - Повний RBAC з явною матрицею дозволів без успадкування ролей та аудит-логом дій
 
@@ -86,9 +87,9 @@
 │  │              CORE MODULES                         │   │
 │  │  AuthModule · UsersModule · ScheduleModule        │   │
 │  │  CoursesModule · SurveysModule                    │   │
-│  │  NotificationsModule · ReferencesModule           │   │
-│  │  ElectiveDisciplinesModule · ReportsModule         │   │
-│  │  AuditLogModule · FilesModule                      │   │
+│  │  NotificationsModule · NewsModule                  │   │
+│  │  ReferencesModule · ElectiveDisciplinesModule      │   │
+│  │  ReportsModule · AuditLogModule · FilesModule      │   │
 │  │  DatabaseMigrationsModule · MaupStudentApiModule   │   │
 │  └──────────────────────────────────────────────────┘   │
 │                                                          │
@@ -599,6 +600,27 @@ replicas потрібен Redis/NATS adapter.
 | `new_survey`      | Опубліковано нове опитування             |
 | `announcement`    | Адмін надіслав оголошення                |
 | `system`          | Технічні повідомлення                    |
+
+---
+
+### 4.8.1 NewsModule
+
+**Файли:** `src/news/`
+
+**Відповідальність:** читання офіційної RSS/Atom-стрічки МАУП через backend,
+нормалізація новин для інтерфейсу та безпечний fallback, якщо зовнішній сайт
+тимчасово недоступний.
+
+**Поточна реалізація:**
+
+- `GET /news?limit=1..20` доступний авторизованим користувачам;
+- source URL за замовчуванням — публічна RSS-стрічка
+  `https://maup.com.ua/ua/feed.xml`;
+- backend обмежує host через `MAUP_NEWS_FEED_ALLOWED_HOST`, перевіряє розмір
+  відповіді, використовує timeout і короткий in-memory cache;
+- якщо RSS недоступний, API повертає кешовані дані як `stale`, а без кешу —
+  порожній список із `unavailable=true`, щоб dashboard не падав;
+- frontend має сторінку `/news` і компактний блок новин на dashboard.
 
 ---
 
@@ -1153,6 +1175,12 @@ MongoDB разом із причиною, actor-метаданими та ост
 | PATCH | `/notifications/read-all`     | Авторизований |
 | POST  | `/notifications/broadcast`    | admin         |
 
+### Новини `/api/news`
+
+| Метод | Шлях               | Доступ        |
+| ----- | ------------------ | ------------- |
+| GET   | `/news?limit=1..20` | Авторизований |
+
 ### Довідники `/api/references`
 
 | Метод           | Шлях                      | Доступ        |
@@ -1267,10 +1295,11 @@ read-only каталог користувачів; управлінські ро
 | 8   | ReferencesModule                                        | ✅ CRUD, admin UI, integrity, import/export |
 | 9   | NotificationsModule                                     | ✅ In-app сценарії реалізовано              |
 | 10  | UsersModule                                             | ✅ Paginated каталог, multi-part пошук, admin mutations, rector/president read-only |
-| 11  | React auth flow (Zustand, cookies, interceptors)         | ✅ Реалізовано                              |
-| 12  | React layout, lazy routes, RBAC navigation, i18n         | ✅ Реалізовано                              |
-| 13  | Role-based frontend pages                               | ✅ 20 page components                       |
-| 14  | Docker Compose + MongoDB replica set                    | ✅ Реалізовано                              |
+| 11  | NewsModule                                              | ✅ MAUP RSS feed, backend cache/fallback, `/news` UI |
+| 12  | React auth flow (Zustand, cookies, interceptors)         | ✅ Реалізовано                              |
+| 13  | React layout, lazy routes, RBAC navigation, i18n         | ✅ Реалізовано                              |
+| 14  | Role-based frontend pages                               | ✅ 21 page components                       |
+| 15  | Docker Compose + MongoDB replica set                    | ✅ Реалізовано                              |
 
 ### Фаза 2 — База даних + File Upload + Опитування
 
@@ -1446,6 +1475,13 @@ online_campus/
 │       │   ├── notifications.controller.ts
 │       │   └── notifications.service.ts
 │       │
+│       ├── news/              # MAUP RSS/Atom feed proxy with cache/fallback
+│       │   ├── dto/
+│       │   ├── news.module.ts
+│       │   ├── news.controller.ts
+│       │   ├── news.service.ts
+│       │   └── news.types.ts
+│       │
 │       ├── files/             # file upload/download/delete and metadata
 │       │   ├── dto/
 │       │   ├── file.schema.ts
@@ -1533,6 +1569,7 @@ online_campus/
         ├── services/
         │   ├── api.ts
         │   ├── notificationsApi.ts
+        │   ├── newsApi.ts
         │   ├── surveysApi.ts
         │   ├── electivesApi.ts
         │   ├── reportsApi.ts
@@ -1557,6 +1594,7 @@ online_campus/
             │   └── ForgotPasswordPage.tsx
             ├── shared/
             │   ├── DashboardPage.tsx
+            │   ├── NewsPage.tsx
             │   ├── SchedulePage.tsx
             │   ├── NotificationsPage.tsx
             │   ├── ProfilePage.tsx
@@ -1683,6 +1721,14 @@ MAUP_API_RETRY_ATTEMPTS=2
 MAUP_API_CIRCUIT_FAILURE_THRESHOLD=5
 MAUP_API_CIRCUIT_RESET_TIMEOUT_MS=30000
 MAUP_API_MAX_RESPONSE_BYTES=5000000
+
+# Public MAUP news RSS feed (no credentials)
+MAUP_NEWS_FEED_URL=https://maup.com.ua/ua/feed.xml
+MAUP_NEWS_FEED_ALLOWED_HOST=maup.com.ua
+MAUP_NEWS_FEED_CACHE_TTL_MS=600000
+MAUP_NEWS_FEED_TIMEOUT_MS=5000
+MAUP_NEWS_FEED_MAX_ITEMS=12
+MAUP_NEWS_FEED_MAX_RESPONSE_BYTES=1000000
 
 SWAGGER_ENABLED=false
 

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -21,6 +21,7 @@ const GradesPage = lazy(() => import('./pages/student/GradesPage'));
 const NotificationsPage = lazy(
   () => import('./pages/shared/NotificationsPage'),
 );
+const NewsPage = lazy(() => import('./pages/shared/NewsPage'));
 const UsersPage = lazy(() => import('./pages/admin/UsersPage'));
 const AuditLogPage = lazy(() => import('./pages/admin/AuditLogPage'));
 const ReportsPage = lazy(() => import('./pages/shared/ReportsPage'));
@@ -237,6 +238,14 @@ export default function App() {
             element={
               <LazyPage>
                 <NotificationsPage />
+              </LazyPage>
+            }
+          />
+          <Route
+            path="news"
+            element={
+              <LazyPage>
+                <NewsPage />
               </LazyPage>
             }
           />

--- a/client/src/components/Layout.tsx
+++ b/client/src/components/Layout.tsx
@@ -15,6 +15,7 @@ const NAV_ITEMS: {
 }[] = [
   { labelKey: 'nav.profile', path: '/profile', roles: ALL_ROLES },
   { labelKey: 'nav.dashboard', path: '/dashboard', roles: ALL_ROLES },
+  { labelKey: 'nav.news', path: '/news', roles: ALL_ROLES },
   { labelKey: 'nav.schedule', path: '/schedule', roles: ALL_ROLES },
   {
     labelKey: 'nav.courses',
@@ -148,6 +149,8 @@ export default function Layout() {
         return t('nav.users');
       case '/notifications':
         return t('nav.notifications');
+      case '/news':
+        return t('nav.news');
       case '/audit-log':
         return t('nav.auditLog');
       case '/reports':

--- a/client/src/components/dashboard/CampusNewsCard.tsx
+++ b/client/src/components/dashboard/CampusNewsCard.tsx
@@ -1,0 +1,93 @@
+import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import type { NewsItem } from '../../services/newsApi';
+
+type Props = {
+  items: NewsItem[];
+  isLoading: boolean;
+  unavailable: boolean;
+};
+
+function formatNewsDate(value: string | undefined, locale: string) {
+  if (!value) {
+    return null;
+  }
+
+  const date = new Date(value.replace(' ', 'T'));
+  if (Number.isNaN(date.getTime())) {
+    return value.slice(0, 10);
+  }
+
+  return new Intl.DateTimeFormat(locale, {
+    day: 'numeric',
+    month: 'short',
+  }).format(date);
+}
+
+export default function CampusNewsCard({
+  items,
+  isLoading,
+  unavailable,
+}: Props) {
+  const { t, i18n } = useTranslation();
+  const locale = i18n.language.startsWith('en') ? 'en-US' : 'uk-UA';
+
+  return (
+    <div className="rounded-[28px] border border-slate-200 bg-white p-6 shadow-[0_10px_30px_rgba(15,23,42,0.06)]">
+      <div className="mb-5 flex items-start justify-between gap-4">
+        <div>
+          <h3 className="text-lg font-semibold text-slate-900">
+            {t('dashboard.newsTitle')}
+          </h3>
+          <p className="mt-2 text-sm leading-6 text-slate-500">
+            {t('dashboard.newsSubtitle')}
+          </p>
+        </div>
+
+        <Link
+          to="/news"
+          className="shrink-0 rounded-full bg-blue-50 px-4 py-2 text-sm font-medium text-blue-700 transition hover:bg-blue-100">
+          {t('dashboard.newsAll')}
+        </Link>
+      </div>
+
+      {isLoading ? (
+        <p className="text-sm text-slate-500">{t('common.loading')}</p>
+      ) : items.length === 0 ? (
+        <div className="rounded-3xl bg-slate-50 px-6 py-5">
+          <p className="text-sm leading-6 text-slate-500">
+            {unavailable ? t('dashboard.newsUnavailable') : t('dashboard.newsEmpty')}
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {items.map((item) => (
+            <a
+              key={item.id}
+              href={item.url}
+              target="_blank"
+              rel="noreferrer"
+              className="block rounded-2xl bg-slate-50 px-5 py-4 transition hover:bg-slate-100">
+              <div className="flex items-start justify-between gap-3">
+                <p className="text-sm font-semibold text-slate-900">
+                  {item.title}
+                </p>
+                {formatNewsDate(item.publishedAt, locale) && (
+                  <span className="shrink-0 text-xs font-medium text-slate-400">
+                    {formatNewsDate(item.publishedAt, locale)}
+                  </span>
+                )}
+              </div>
+
+              {item.summary && (
+                <p className="mt-2 line-clamp-2 text-sm leading-6 text-slate-500">
+                  {item.summary}
+                </p>
+              )}
+            </a>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/i18n.ts
+++ b/client/src/i18n.ts
@@ -9,6 +9,7 @@ const resources = {
       'app.subtitle': 'Електронний кампус академії',
 
       'nav.dashboard': 'Дашборд',
+      'nav.news': 'Новини',
       'nav.schedule': 'Розклад',
       'nav.courses': 'Мої дисципліни',
       'nav.assignments': 'Завдання',
@@ -143,6 +144,13 @@ const resources = {
 
       'dashboard.surveysTitle': 'Важливі опитування',
       'dashboard.noSurveys': 'Наразі активних опитувань немає.',
+
+      'dashboard.newsTitle': 'Новини МАУП',
+      'dashboard.newsSubtitle': 'Останні публікації з офіційної стрічки.',
+      'dashboard.newsAll': 'Усі новини',
+      'dashboard.newsEmpty': 'Новин поки немає.',
+      'dashboard.newsUnavailable':
+        'Не вдалося оновити стрічку новин. Спробуйте пізніше.',
 
       'dashboard.adminPanel': 'Адмін-панель',
       'dashboard.usersCount': 'Користувачі',
@@ -391,6 +399,18 @@ const resources = {
       'common.cancel': 'Скасувати',
       'common.edit': 'Редагувати',
       'common.delete': 'Видалити',
+
+      'news.title': 'Новини МАУП',
+      'news.subtitle':
+        'Останні матеріали з офіційної RSS-стрічки МАУП. Посилання відкриваються на сайті академії.',
+      'news.source': 'Офіційна стрічка МАУП',
+      'news.lastUpdated': 'Оновлено: {{date}}',
+      'news.refresh': 'Оновити',
+      'news.loading': 'Завантажуємо новини...',
+      'news.empty': 'Новин поки немає.',
+      'news.unavailable':
+        'Стрічка новин тимчасово недоступна. Якщо є кешовані дані, система покаже їх автоматично.',
+      'news.open': 'Відкрити на сайті',
 
       'layout.supportTitle': 'Підтримка',
       'layout.supportText':
@@ -1031,6 +1051,7 @@ const resources = {
       'app.subtitle': 'Academy electronic campus',
 
       'nav.dashboard': 'Dashboard',
+      'nav.news': 'News',
       'nav.schedule': 'Schedule',
       'nav.courses': 'My courses',
       'nav.assignments': 'Assignments',
@@ -1163,6 +1184,13 @@ const resources = {
 
       'dashboard.surveysTitle': 'Important surveys',
       'dashboard.noSurveys': 'There are no active surveys right now.',
+
+      'dashboard.newsTitle': 'IAPM news',
+      'dashboard.newsSubtitle': 'Latest posts from the official feed.',
+      'dashboard.newsAll': 'All news',
+      'dashboard.newsEmpty': 'There are no news posts yet.',
+      'dashboard.newsUnavailable':
+        'Could not refresh the news feed. Try again later.',
 
       'dashboard.adminPanel': 'Admin panel',
       'dashboard.usersCount': 'Users',
@@ -1414,6 +1442,18 @@ const resources = {
       'common.cancel': 'Cancel',
       'common.edit': 'Edit',
       'common.delete': 'Delete',
+
+      'news.title': 'IAPM news',
+      'news.subtitle':
+        'Latest posts from the official IAPM RSS feed. Links open on the academy website.',
+      'news.source': 'Official IAPM feed',
+      'news.lastUpdated': 'Updated: {{date}}',
+      'news.refresh': 'Refresh',
+      'news.loading': 'Loading news...',
+      'news.empty': 'There are no news posts yet.',
+      'news.unavailable':
+        'The news feed is temporarily unavailable. If cached data exists, the system will show it automatically.',
+      'news.open': 'Open on website',
 
       'layout.supportTitle': 'Support',
       'layout.supportText': 'Contact technical support via bot or email.',

--- a/client/src/pages/shared/DashboardPage.tsx
+++ b/client/src/pages/shared/DashboardPage.tsx
@@ -6,6 +6,8 @@ import PerformanceCard from '../../components/dashboard/PerformanceCard';
 import TodayScheduleCard from '../../components/dashboard/TodayScheduleCard';
 import DeadlinesCard from '../../components/dashboard/DeadlinesCard';
 import SurveyHighlightCard from '../../components/dashboard/SurveyHighlightCard';
+import CampusNewsCard from '../../components/dashboard/CampusNewsCard';
+import { newsApi, type NewsItem } from '../../services/newsApi';
 
 export type ScheduleItem = {
   id?: string;
@@ -52,6 +54,8 @@ export default function DashboardPage() {
   const { user } = useAuthStore();
   const [schedule, setSchedule] = useState<ScheduleItem[]>([]);
   const [notifications, setNotifications] = useState<NotificationItem[]>([]);
+  const [news, setNews] = useState<NewsItem[]>([]);
+  const [newsUnavailable, setNewsUnavailable] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
@@ -60,10 +64,12 @@ export default function DashboardPage() {
     const loadDashboardData = async () => {
       setIsLoading(true);
 
-      const [scheduleResult, notificationsResult] = await Promise.allSettled([
-        api.get('/schedule/my'),
-        api.get('/notifications'),
-      ]);
+      const [scheduleResult, notificationsResult, newsResult] =
+        await Promise.allSettled([
+          api.get('/schedule/my'),
+          api.get('/notifications'),
+          newsApi.listLatest(3),
+        ]);
 
       if (!isMounted) return;
 
@@ -79,6 +85,14 @@ export default function DashboardPage() {
         );
       } else {
         setNotifications([]);
+      }
+
+      if (newsResult.status === 'fulfilled') {
+        setNews(newsResult.value.items);
+        setNewsUnavailable(newsResult.value.unavailable);
+      } else {
+        setNews([]);
+        setNewsUnavailable(true);
       }
 
       setIsLoading(false);
@@ -121,6 +135,11 @@ export default function DashboardPage() {
 
         <div className="space-y-6">
           <TodayScheduleCard items={todaySchedule} isLoading={isLoading} />
+          <CampusNewsCard
+            items={news}
+            isLoading={isLoading}
+            unavailable={newsUnavailable}
+          />
 
           <div className="grid gap-6 lg:grid-cols-2">
             <DeadlinesCard items={notifications} />

--- a/client/src/pages/shared/NewsPage.tsx
+++ b/client/src/pages/shared/NewsPage.tsx
@@ -1,0 +1,135 @@
+import { useQuery } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import { newsApi, newsQueryKeys, type NewsItem } from '../../services/newsApi';
+
+function formatDateTime(value: string | null | undefined, locale: string) {
+  if (!value) {
+    return null;
+  }
+
+  const date = new Date(value.replace(' ', 'T'));
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return new Intl.DateTimeFormat(locale, {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(date);
+}
+
+function NewsCard({ item, locale }: { item: NewsItem; locale: string }) {
+  const { t } = useTranslation();
+  const publishedAt = formatDateTime(item.publishedAt, locale);
+
+  return (
+    <article className="flex h-full flex-col rounded-[28px] border border-slate-200 bg-white p-6 shadow-[0_10px_30px_rgba(15,23,42,0.06)]">
+      {publishedAt && (
+        <p className="text-xs font-semibold uppercase tracking-wide text-blue-600">
+          {publishedAt}
+        </p>
+      )}
+
+      <h3 className="mt-3 text-lg font-semibold leading-7 text-slate-900">
+        {item.title}
+      </h3>
+
+      {item.summary && (
+        <p className="mt-3 flex-1 text-sm leading-6 text-slate-500">
+          {item.summary}
+        </p>
+      )}
+
+      <a
+        href={item.url}
+        target="_blank"
+        rel="noreferrer"
+        className="mt-5 inline-flex w-fit rounded-full bg-blue-600 px-5 py-2 text-sm font-medium text-white transition hover:bg-blue-700">
+        {t('news.open')}
+      </a>
+    </article>
+  );
+}
+
+export default function NewsPage() {
+  const { t, i18n } = useTranslation();
+  const locale = i18n.language.startsWith('en') ? 'en-US' : 'uk-UA';
+  const limit = 12;
+
+  const {
+    data,
+    isError,
+    isFetching,
+    isLoading,
+    refetch,
+  } = useQuery({
+    queryKey: newsQueryKeys.latest(limit),
+    queryFn: () => newsApi.listLatest(limit),
+    refetchOnMount: true,
+    refetchOnReconnect: true,
+    refetchOnWindowFocus: false,
+    retry: 1,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const items = data?.items ?? [];
+  const statusText =
+    data?.unavailable || isError
+      ? t('news.unavailable')
+      : data?.fetchedAt
+        ? t('news.lastUpdated', {
+            date: formatDateTime(data.fetchedAt, locale),
+          })
+        : t('news.source');
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-[32px] bg-gradient-to-br from-blue-700 to-slate-900 p-8 text-white shadow-[0_14px_38px_rgba(15,23,42,0.18)]">
+        <div className="flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <p className="text-sm font-semibold uppercase tracking-[0.2em] text-blue-100">
+              {t('news.source')}
+            </p>
+            <h1 className="mt-3 text-3xl font-bold tracking-tight">
+              {t('news.title')}
+            </h1>
+            <p className="mt-3 max-w-3xl text-sm leading-6 text-blue-50">
+              {t('news.subtitle')}
+            </p>
+          </div>
+
+          <button
+            type="button"
+            onClick={() => void refetch()}
+            disabled={isFetching}
+            className="w-fit rounded-full bg-white px-5 py-2 text-sm font-semibold text-blue-700 transition hover:bg-blue-50 disabled:cursor-not-allowed disabled:opacity-70">
+            {isFetching ? t('common.loading') : t('news.refresh')}
+          </button>
+        </div>
+      </div>
+
+      <div className="rounded-3xl border border-slate-200 bg-white px-5 py-4 text-sm text-slate-500">
+        {statusText}
+      </div>
+
+      {isLoading ? (
+        <div className="rounded-[28px] border border-slate-200 bg-white p-8 text-sm text-slate-500">
+          {t('news.loading')}
+        </div>
+      ) : items.length === 0 ? (
+        <div className="rounded-[28px] border border-slate-200 bg-white p-8 text-sm text-slate-500">
+          {data?.unavailable || isError ? t('news.unavailable') : t('news.empty')}
+        </div>
+      ) : (
+        <div className="grid gap-6 lg:grid-cols-2 xl:grid-cols-3">
+          {items.map((item) => (
+            <NewsCard key={item.id} item={item} locale={locale} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/services/newsApi.ts
+++ b/client/src/services/newsApi.ts
@@ -1,0 +1,49 @@
+import api from './api';
+
+export interface NewsItem {
+  id: string;
+  title: string;
+  summary: string;
+  url: string;
+  publishedAt?: string;
+}
+
+export interface NewsFeedResponse {
+  items: NewsItem[];
+  sourceUrl: string;
+  fetchedAt: string | null;
+  cached: boolean;
+  stale: boolean;
+  unavailable: boolean;
+}
+
+export const newsQueryKeys = {
+  latest: (limit: number) => ['news', 'latest', limit] as const,
+};
+
+export const newsApi = {
+  async listLatest(limit = 6): Promise<NewsFeedResponse> {
+    const { data } = await api.get<NewsFeedResponse>('/news', {
+      params: { limit },
+    });
+
+    return {
+      items: Array.isArray(data.items) ? data.items.map(normalizeNewsItem) : [],
+      sourceUrl: data.sourceUrl ?? '',
+      fetchedAt: data.fetchedAt ?? null,
+      cached: data.cached === true,
+      stale: data.stale === true,
+      unavailable: data.unavailable === true,
+    };
+  },
+};
+
+function normalizeNewsItem(item: NewsItem): NewsItem {
+  return {
+    id: item.id ?? item.url ?? item.title,
+    title: item.title ?? '',
+    summary: item.summary ?? '',
+    url: item.url ?? '',
+    publishedAt: item.publishedAt,
+  };
+}

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -26,6 +26,7 @@ import { validateEnvironment } from './config/environment.validation';
 import { DatabaseMigrationsModule } from './database-migrations/database-migrations.module';
 import { HealthController } from './health.controller';
 import { MaupStudentApiModule } from './integrations/maup-student-api/maup-student-api.module';
+import { NewsModule } from './news/news.module';
 
 mongoose.set('transactionAsyncLocalStorage', true);
 
@@ -113,6 +114,7 @@ function buildMongoUri(config: ConfigService): string {
     ElectiveDisciplinesModule,
     ReportsModule,
     MaupStudentApiModule,
+    NewsModule,
   ],
   controllers: [HealthController],
   providers: [

--- a/server/src/config/environment.validation.spec.ts
+++ b/server/src/config/environment.validation.spec.ts
@@ -82,6 +82,8 @@ describe('validateEnvironment', () => {
     expect(result.PASSWORD_RESET_EMAIL_ENABLED).toBe('false');
     expect(result.MAUP_API_ENABLED).toBe('false');
     expect(result.MAUP_API_BASE_URL).toBe('');
+    expect(result.MAUP_NEWS_FEED_URL).toBe('https://maup.com.ua/ua/feed.xml');
+    expect(result.MAUP_NEWS_FEED_ALLOWED_HOST).toBe('maup.com.ua');
   });
 
   it('requires credentials only when the MAUP integration is enabled', () => {
@@ -117,6 +119,17 @@ describe('validateEnvironment', () => {
         MAUP_API_PASSWORD: 'integration-password',
       }),
     ).toThrow(/MAUP_API_BASE_URL must use HTTPS in production/);
+  });
+
+  it('restricts the MAUP news feed to the approved host', () => {
+    expect(() =>
+      validateEnvironment({
+        NODE_ENV: 'test',
+        MONGODB_URI: 'mongodb://127.0.0.1:27017/campus-test',
+        MAUP_NEWS_FEED_URL: 'https://example.com/feed.xml',
+        MAUP_NEWS_FEED_ALLOWED_HOST: 'maup.com.ua',
+      }),
+    ).toThrow(/MAUP_NEWS_FEED_URL must use MAUP_NEWS_FEED_ALLOWED_HOST/);
   });
 
   it('requires an authenticated password-reset email transport in production', () => {

--- a/server/src/config/environment.validation.ts
+++ b/server/src/config/environment.validation.ts
@@ -77,6 +77,7 @@ export function validateEnvironment(input: Environment): Environment {
     'POST',
     errors,
   );
+  validateMaupNewsFeed(env, isProduction, errors);
 
   const jwtSecret = readSecret(
     env,
@@ -162,6 +163,42 @@ export function validateEnvironment(input: Environment): Environment {
   }
 
   return env;
+}
+
+function validateMaupNewsFeed(
+  env: Environment,
+  isProduction: boolean,
+  errors: string[],
+): void {
+  const rawFeedUrl =
+    readOptionalString(env, 'MAUP_NEWS_FEED_URL') ??
+    'https://maup.com.ua/ua/feed.xml';
+  const allowedHost =
+    readOptionalString(env, 'MAUP_NEWS_FEED_ALLOWED_HOST') ?? 'maup.com.ua';
+
+  env.MAUP_NEWS_FEED_ALLOWED_HOST = allowedHost;
+
+  try {
+    const url = new URL(rawFeedUrl);
+    if (!['http:', 'https:'].includes(url.protocol)) {
+      errors.push('MAUP_NEWS_FEED_URL must use HTTP or HTTPS');
+    }
+    if (url.username || url.password || url.hash) {
+      errors.push(
+        'MAUP_NEWS_FEED_URL must not contain credentials or a fragment',
+      );
+    }
+    if (isProduction && url.protocol !== 'https:') {
+      errors.push('MAUP_NEWS_FEED_URL must use HTTPS in production');
+    }
+    if (!isAllowedHost(url.hostname, allowedHost)) {
+      errors.push('MAUP_NEWS_FEED_URL must use MAUP_NEWS_FEED_ALLOWED_HOST');
+    }
+    env.MAUP_NEWS_FEED_URL = url.toString();
+  } catch {
+    errors.push('MAUP_NEWS_FEED_URL must be a valid absolute URL');
+    env.MAUP_NEWS_FEED_URL = rawFeedUrl;
+  }
 }
 
 function validateMaupStudentApi(
@@ -359,11 +396,24 @@ function validatePositiveTuning(env: Environment, errors: string[]): void {
     ['MAUP_API_CIRCUIT_FAILURE_THRESHOLD', 5, 1, 100],
     ['MAUP_API_CIRCUIT_RESET_TIMEOUT_MS', 30_000, 1_000, 600_000],
     ['MAUP_API_MAX_RESPONSE_BYTES', 5_000_000, 1_024, 50_000_000],
+    ['MAUP_NEWS_FEED_CACHE_TTL_MS', 600_000, 60_000, 3_600_000],
+    ['MAUP_NEWS_FEED_TIMEOUT_MS', 5_000, 500, 60_000],
+    ['MAUP_NEWS_FEED_MAX_ITEMS', 12, 1, 20],
+    ['MAUP_NEWS_FEED_MAX_RESPONSE_BYTES', 1_000_000, 1_024, 5_000_000],
   ];
 
   for (const [key, fallback, min, max] of definitions) {
     env[key] = String(readInteger(env, key, fallback, min, max, errors));
   }
+}
+
+function isAllowedHost(hostname: string, allowedHost: string): boolean {
+  const normalizedHostname = hostname.toLowerCase();
+  const normalizedAllowedHost = allowedHost.toLowerCase();
+  return (
+    normalizedHostname === normalizedAllowedHost ||
+    normalizedHostname.endsWith(`.${normalizedAllowedHost}`)
+  );
 }
 
 function readClientUrl(

--- a/server/src/news/dto/news-query.dto.ts
+++ b/server/src/news/dto/news-query.dto.ts
@@ -1,0 +1,11 @@
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, Max, Min } from 'class-validator';
+
+export class NewsQueryDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(20)
+  limit?: number;
+}

--- a/server/src/news/news.controller.ts
+++ b/server/src/news/news.controller.ts
@@ -1,0 +1,19 @@
+import { Controller, Get, Header, Query, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { NewsQueryDto } from './dto/news-query.dto';
+import { NewsService } from './news.service';
+
+@ApiTags('news')
+@ApiBearerAuth()
+@Controller('news')
+@UseGuards(JwtAuthGuard)
+export class NewsController {
+  constructor(private readonly newsService: NewsService) {}
+
+  @Get()
+  @Header('Cache-Control', 'private, max-age=60')
+  findLatest(@Query() query: NewsQueryDto) {
+    return this.newsService.findLatest(query.limit);
+  }
+}

--- a/server/src/news/news.module.ts
+++ b/server/src/news/news.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { NewsController } from './news.controller';
+import { NEWS_FEED_FETCH, NewsService } from './news.service';
+
+@Module({
+  controllers: [NewsController],
+  providers: [
+    NewsService,
+    {
+      provide: NEWS_FEED_FETCH,
+      useValue: fetch,
+    },
+  ],
+})
+export class NewsModule {}

--- a/server/src/news/news.service.spec.ts
+++ b/server/src/news/news.service.spec.ts
@@ -1,0 +1,139 @@
+import { ConfigService } from '@nestjs/config';
+import { NewsFetch, NewsService } from './news.service';
+
+const SAMPLE_RSS = `<?xml version="1.0" encoding="utf-8" ?>
+<rss version="2.0">
+  <channel>
+    <title>МАУП</title>
+    <item>
+      <title>Перша новина МАУП</title>
+      <link>https://maup.com.ua/ua/news/first.html</link>
+      <guid isPermaLink="true">https://maup.com.ua/ua/news/first.html</guid>
+      <description><![CDATA[ Текст із <strong>HTML</strong> та &laquo;лапками&raquo;. ]]></description>
+      <pubDate>2026-06-25 00:59:27</pubDate>
+    </item>
+    <item>
+      <title>Зовнішнє посилання</title>
+      <link>https://example.com/news.html</link>
+      <description>Не має пройти host allowlist</description>
+    </item>
+  </channel>
+</rss>`;
+
+function createService(
+  fetchMock: jest.MockedFunction<NewsFetch>,
+  overrides: Record<string, string> = {},
+) {
+  const values: Record<string, string> = {
+    MAUP_NEWS_FEED_URL: 'https://maup.com.ua/ua/feed.xml',
+    MAUP_NEWS_FEED_ALLOWED_HOST: 'maup.com.ua',
+    MAUP_NEWS_FEED_CACHE_TTL_MS: '600000',
+    MAUP_NEWS_FEED_TIMEOUT_MS: '1000',
+    MAUP_NEWS_FEED_MAX_ITEMS: '12',
+    MAUP_NEWS_FEED_MAX_RESPONSE_BYTES: '100000',
+    ...overrides,
+  };
+  const config = {
+    get: jest.fn((key: string) => values[key]),
+  } as unknown as ConfigService;
+
+  return new NewsService(config, fetchMock);
+}
+
+function xmlResponse(xml: string) {
+  return Promise.resolve(
+    new Response(xml, {
+      status: 200,
+      headers: {
+        'content-length': String(Buffer.byteLength(xml, 'utf8')),
+        'content-type': 'text/xml; charset=UTF-8',
+      },
+    }),
+  );
+}
+
+describe('NewsService', () => {
+  let fetchMock: jest.MockedFunction<NewsFetch>;
+
+  beforeEach(() => {
+    fetchMock = jest.fn<ReturnType<NewsFetch>, Parameters<NewsFetch>>();
+  });
+
+  it('loads, sanitizes and normalizes the MAUP RSS feed', async () => {
+    fetchMock.mockReturnValueOnce(xmlResponse(SAMPLE_RSS));
+    const service = createService(fetchMock);
+
+    const result = await service.findLatest(10);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [URL, RequestInit];
+    expect(url.toString()).toBe('https://maup.com.ua/ua/feed.xml');
+    expect((init.headers as Record<string, string>).Accept).toContain(
+      'application/rss+xml',
+    );
+    expect(result).toEqual(
+      expect.objectContaining({
+        cached: false,
+        stale: false,
+        unavailable: false,
+        sourceUrl: 'https://maup.com.ua/ua/feed.xml',
+      }),
+    );
+    expect(result.items).toEqual([
+      {
+        id: 'https://maup.com.ua/ua/news/first.html',
+        title: 'Перша новина МАУП',
+        summary: 'Текст із HTML та «лапками».',
+        url: 'https://maup.com.ua/ua/news/first.html',
+        publishedAt: '2026-06-25 00:59:27',
+      },
+    ]);
+  });
+
+  it('serves fresh responses from cache within the configured TTL', async () => {
+    fetchMock.mockReturnValueOnce(xmlResponse(SAMPLE_RSS));
+    const service = createService(fetchMock);
+
+    await service.findLatest(1);
+    const cached = await service.findLatest(1);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(cached.cached).toBe(true);
+    expect(cached.stale).toBe(false);
+    expect(cached.items).toHaveLength(1);
+  });
+
+  it('returns stale cache instead of failing the dashboard', async () => {
+    const nowSpy = jest.spyOn(Date, 'now');
+    nowSpy.mockReturnValueOnce(1_000);
+    fetchMock.mockReturnValueOnce(xmlResponse(SAMPLE_RSS));
+    const service = createService(fetchMock, {
+      MAUP_NEWS_FEED_CACHE_TTL_MS: '1',
+    });
+
+    await service.findLatest(1);
+
+    nowSpy.mockReturnValueOnce(2_000);
+    fetchMock.mockRejectedValueOnce(new Error('network error'));
+    const stale = await service.findLatest(1);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(stale.cached).toBe(true);
+    expect(stale.stale).toBe(true);
+    expect(stale.unavailable).toBe(true);
+    expect(stale.items).toHaveLength(1);
+
+    nowSpy.mockRestore();
+  });
+
+  it('returns an empty unavailable feed when there is no cache', async () => {
+    fetchMock.mockRejectedValueOnce(new Error('network error'));
+    const service = createService(fetchMock);
+
+    const result = await service.findLatest(3);
+
+    expect(result.items).toEqual([]);
+    expect(result.unavailable).toBe(true);
+    expect(result.fetchedAt).toBeNull();
+  });
+});

--- a/server/src/news/news.service.ts
+++ b/server/src/news/news.service.ts
@@ -1,0 +1,342 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { NewsFeedResponse, NewsItem } from './news.types';
+
+export const NEWS_FEED_FETCH = Symbol('NEWS_FEED_FETCH');
+export type NewsFetch = typeof fetch;
+
+type CachedFeed = {
+  feed: NewsFeedResponse;
+  expiresAt: number;
+};
+
+const DEFAULT_FEED_URL = 'https://maup.com.ua/ua/feed.xml';
+const DEFAULT_ALLOWED_HOST = 'maup.com.ua';
+const DEFAULT_LIMIT = 6;
+const MAX_LIMIT = 20;
+
+@Injectable()
+export class NewsService {
+  private readonly logger = new Logger(NewsService.name);
+  private readonly feedUrl: URL;
+  private readonly allowedHost: string;
+  private readonly cacheTtlMs: number;
+  private readonly timeoutMs: number;
+  private readonly maxItems: number;
+  private readonly maxResponseBytes: number;
+
+  private cache?: CachedFeed;
+
+  constructor(
+    private readonly config: ConfigService,
+    @Inject(NEWS_FEED_FETCH) private readonly fetchImpl: NewsFetch,
+  ) {
+    this.feedUrl = new URL(
+      this.config.get<string>('MAUP_NEWS_FEED_URL') ?? DEFAULT_FEED_URL,
+    );
+    this.allowedHost =
+      this.config.get<string>('MAUP_NEWS_FEED_ALLOWED_HOST') ??
+      DEFAULT_ALLOWED_HOST;
+    this.cacheTtlMs = this.readNumber('MAUP_NEWS_FEED_CACHE_TTL_MS', 600_000);
+    this.timeoutMs = this.readNumber('MAUP_NEWS_FEED_TIMEOUT_MS', 5_000);
+    this.maxItems = Math.min(
+      this.readNumber('MAUP_NEWS_FEED_MAX_ITEMS', 12),
+      MAX_LIMIT,
+    );
+    this.maxResponseBytes = this.readNumber(
+      'MAUP_NEWS_FEED_MAX_RESPONSE_BYTES',
+      1_000_000,
+    );
+  }
+
+  async findLatest(limit = DEFAULT_LIMIT): Promise<NewsFeedResponse> {
+    const safeLimit = clampLimit(limit);
+    const now = Date.now();
+
+    if (this.cache && this.cache.expiresAt > now) {
+      return this.withFlags(this.cache.feed, safeLimit, {
+        cached: true,
+        stale: false,
+        unavailable: false,
+      });
+    }
+
+    try {
+      const feed = await this.fetchFeed();
+      this.cache = {
+        feed,
+        expiresAt: now + this.cacheTtlMs,
+      };
+
+      return this.withFlags(feed, safeLimit, {
+        cached: false,
+        stale: false,
+        unavailable: false,
+      });
+    } catch (error: unknown) {
+      this.logger.warn(
+        `MAUP news feed unavailable: ${error instanceof Error ? error.message : 'unknown error'}`,
+      );
+
+      if (this.cache) {
+        return this.withFlags(this.cache.feed, safeLimit, {
+          cached: true,
+          stale: true,
+          unavailable: true,
+        });
+      }
+
+      return {
+        items: [],
+        sourceUrl: this.feedUrl.toString(),
+        fetchedAt: null,
+        cached: false,
+        stale: false,
+        unavailable: true,
+      };
+    }
+  }
+
+  private async fetchFeed(): Promise<NewsFeedResponse> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    timer.unref();
+
+    try {
+      const response = await this.fetchImpl(this.feedUrl, {
+        headers: {
+          Accept: 'application/rss+xml, application/atom+xml, text/xml',
+        },
+        signal: controller.signal,
+      });
+
+      const declaredSize = Number(response.headers.get('content-length'));
+      if (
+        Number.isFinite(declaredSize) &&
+        declaredSize > this.maxResponseBytes
+      ) {
+        throw new Error('news feed response is too large');
+      }
+
+      if (!response.ok) {
+        throw new Error(`news feed returned HTTP ${response.status}`);
+      }
+
+      const xml = await response.text();
+      if (Buffer.byteLength(xml, 'utf8') > this.maxResponseBytes) {
+        throw new Error('news feed response is too large');
+      }
+
+      const items = parseNewsFeed(xml)
+        .filter((item) => this.isAllowedNewsUrl(item.url))
+        .slice(0, this.maxItems);
+
+      return {
+        items,
+        sourceUrl: this.feedUrl.toString(),
+        fetchedAt: new Date().toISOString(),
+        cached: false,
+        stale: false,
+        unavailable: false,
+      };
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  private withFlags(
+    feed: NewsFeedResponse,
+    limit: number,
+    flags: Pick<NewsFeedResponse, 'cached' | 'stale' | 'unavailable'>,
+  ): NewsFeedResponse {
+    return {
+      ...feed,
+      ...flags,
+      items: feed.items.slice(0, limit),
+    };
+  }
+
+  private isAllowedNewsUrl(value: string): boolean {
+    try {
+      const url = new URL(value);
+      return isAllowedHost(url.hostname, this.allowedHost);
+    } catch {
+      return false;
+    }
+  }
+
+  private readNumber(key: string, fallback: number): number {
+    const value = Number(this.config.get<string>(key));
+    return Number.isFinite(value) && value >= 0 ? value : fallback;
+  }
+}
+
+export function parseNewsFeed(xml: string): NewsItem[] {
+  const rssItems = matchTagBlocks(xml, 'item');
+  if (rssItems.length > 0) {
+    return rssItems
+      .map((item, index) => parseRssItem(item, index))
+      .filter((item): item is NewsItem => item !== null);
+  }
+
+  return matchTagBlocks(xml, 'entry')
+    .map((item, index) => parseAtomItem(item, index))
+    .filter((item): item is NewsItem => item !== null);
+}
+
+function parseRssItem(block: string, index: number): NewsItem | null {
+  const title = normalizeText(extractTag(block, 'title'));
+  const url = normalizeUrl(extractTag(block, 'link'));
+  const publishedAt = normalizeText(extractTag(block, 'pubDate')) || undefined;
+  const summary = summarize(
+    extractTag(block, 'description') ?? extractTag(block, 'content:encoded'),
+  );
+  const guid = normalizeText(extractTag(block, 'guid'));
+
+  if (!title || !url) {
+    return null;
+  }
+
+  return {
+    id: guid || url || `${title}-${index}`,
+    title,
+    summary,
+    url,
+    publishedAt,
+  };
+}
+
+function parseAtomItem(block: string, index: number): NewsItem | null {
+  const title = normalizeText(extractTag(block, 'title'));
+  const url = normalizeUrl(extractAtomLink(block));
+  const publishedAt =
+    normalizeText(extractTag(block, 'updated')) ||
+    normalizeText(extractTag(block, 'published')) ||
+    undefined;
+  const summary = summarize(
+    extractTag(block, 'summary') ?? extractTag(block, 'content'),
+  );
+  const id = normalizeText(extractTag(block, 'id'));
+
+  if (!title || !url) {
+    return null;
+  }
+
+  return {
+    id: id || url || `${title}-${index}`,
+    title,
+    summary,
+    url,
+    publishedAt,
+  };
+}
+
+function matchTagBlocks(xml: string, tag: string): string[] {
+  const safeTag = escapeRegExp(tag);
+  return Array.from(
+    xml.matchAll(new RegExp(`<${safeTag}\\b[\\s\\S]*?<\\/${safeTag}>`, 'gi')),
+    (match) => match[0],
+  );
+}
+
+function extractTag(block: string, tag: string): string | undefined {
+  const safeTag = escapeRegExp(tag);
+  return block.match(
+    new RegExp(`<${safeTag}(?:\\s[^>]*)?>([\\s\\S]*?)<\\/${safeTag}>`, 'i'),
+  )?.[1];
+}
+
+function extractAtomLink(block: string): string | undefined {
+  return (
+    extractTag(block, 'link') ??
+    block.match(/<link\b[^>]*\bhref=["']([^"']+)["'][^>]*\/?>/i)?.[1]
+  );
+}
+
+function normalizeUrl(value: string | undefined): string {
+  const normalized = normalizeText(value);
+  if (!normalized) {
+    return '';
+  }
+
+  try {
+    const url = new URL(normalized);
+    return ['http:', 'https:'].includes(url.protocol) ? url.toString() : '';
+  } catch {
+    return '';
+  }
+}
+
+function summarize(value: string | undefined): string {
+  const text = normalizeText(value);
+  if (text.length <= 260) {
+    return text;
+  }
+
+  return `${text.slice(0, 257).trim()}…`;
+}
+
+function normalizeText(value: string | undefined): string {
+  if (!value) {
+    return '';
+  }
+
+  return decodeEntities(
+    value
+      .replace(/<!\[CDATA\[([\s\S]*?)\]\]>/g, '$1')
+      .replace(/<[^>]+>/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim(),
+  );
+}
+
+function decodeEntities(value: string): string {
+  const namedEntities: Record<string, string> = {
+    amp: '&',
+    apos: "'",
+    laquo: '«',
+    ldquo: '“',
+    lsquo: '‘',
+    mdash: '—',
+    nbsp: ' ',
+    ndash: '–',
+    quot: '"',
+    raquo: '»',
+    rdquo: '”',
+    rsquo: '’',
+    lt: '<',
+    gt: '>',
+  };
+
+  return value
+    .replace(/&#x([0-9a-f]+);/gi, (_, code: string) =>
+      String.fromCodePoint(Number.parseInt(code, 16)),
+    )
+    .replace(/&#(\d+);/g, (_, code: string) =>
+      String.fromCodePoint(Number.parseInt(code, 10)),
+    )
+    .replace(/&([a-z]+);/gi, (match, entity: string) => {
+      return namedEntities[entity.toLowerCase()] ?? match;
+    });
+}
+
+function clampLimit(limit: number): number {
+  if (!Number.isFinite(limit)) {
+    return DEFAULT_LIMIT;
+  }
+
+  return Math.min(Math.max(Math.trunc(limit), 1), MAX_LIMIT);
+}
+
+function isAllowedHost(hostname: string, allowedHost: string): boolean {
+  const normalizedHostname = hostname.toLowerCase();
+  const normalizedAllowedHost = allowedHost.toLowerCase();
+  return (
+    normalizedHostname === normalizedAllowedHost ||
+    normalizedHostname.endsWith(`.${normalizedAllowedHost}`)
+  );
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/server/src/news/news.types.ts
+++ b/server/src/news/news.types.ts
@@ -1,0 +1,16 @@
+export interface NewsItem {
+  id: string;
+  title: string;
+  summary: string;
+  url: string;
+  publishedAt?: string;
+}
+
+export interface NewsFeedResponse {
+  items: NewsItem[];
+  sourceUrl: string;
+  fetchedAt: string | null;
+  cached: boolean;
+  stale: boolean;
+  unavailable: boolean;
+}


### PR DESCRIPTION
<details>
<summary><strong>Українська версія</strong></summary>

## Підсумок

- Додано backend NewsModule для читання офіційної публічної RSS-стрічки МАУП.
- Додано `/api/news?limit=1..20` для авторизованих користувачів.
- Додано RSS/Atom parsing, allowlist хоста, обмеження розміру відповіді, timeout, in-memory cache і stale fallback.
- Додано сторінку новин і картку новин на dashboard у React.
- Додано українські та англійські i18n-тексти.
- Оновлено README з актуальною поведінкою NewsModule/API та optional public RSS environment variables.

## Перевірка

- `server: npm run lint:check`
- `server: npm test`
- `server: npm run build`
- `client: npm run lint:check`
- `client: npm run build`

</details>

## Summary

- Added a backend NewsModule that reads the official public MAUP RSS feed.
- Added `/api/news?limit=1..20` for authenticated users.
- Added RSS/Atom parsing, host allowlist, response size limit, timeout, in-memory cache, and stale fallback.
- Added a News page and dashboard news card in the React app.
- Added Ukrainian and English i18n strings.
- Updated README with the current NewsModule/API behavior and optional public RSS environment variables.

## Verification

- `server: npm run lint:check`
- `server: npm test`
- `server: npm run build`
- `client: npm run lint:check`
- `client: npm run build`