### PR TITLE
fix: remove redundant explanatory copy from UI pages

### DIFF
--- a/client/src/i18n.ts
+++ b/client/src/i18n.ts
@@ -562,8 +562,6 @@ const resources = {
       'users.searchPlaceholder': 'Пошук за ПІБ...',
       'users.searchButton': 'Знайти',
       'users.allRoles': 'Усі ролі',
-      'users.readOnlyDirectory':
-        'Режим перегляду: редагування, зміна ролей і блокування користувачів недоступні.',
       'users.loading': 'Завантаження користувачів...',
       'users.empty': 'Користувачів не знайдено',
       'users.loadError': 'Не вдалося завантажити користувачів',
@@ -1620,8 +1618,6 @@ const resources = {
       'users.searchPlaceholder': 'Search by full name...',
       'users.searchButton': 'Search',
       'users.allRoles': 'All roles',
-      'users.readOnlyDirectory':
-        'Read-only mode: editing, role changes, and blocking are disabled.',
       'users.loading': 'Loading users...',
       'users.empty': 'No users found',
       'users.loadError': 'Could not load users',

--- a/client/src/i18n.ts
+++ b/client/src/i18n.ts
@@ -276,10 +276,6 @@ const resources = {
       'courses.openMoodle': 'Відкрити Moodle',
       'courses.moodleNoticeText':
         'У кампусі відображаються ваші дисципліни, базова інформація, додаткові матеріали й посилання на онлайн-пари. Завдання та оцінювання ведуться окремо в Moodle.',
-      'courses.detailsMoodleTitle':
-        'Завдання й оцінювання не дублюються в кампусі',
-      'courses.detailsMoodleText':
-        'Використовуйте матеріали дисципліни для силабусів, програм, презентацій та корисних HTTPS-посилань. Для завдань, здачі робіт і оцінок відкрийте Moodle.',
       'courses.academicYear': 'Навчальний рік',
       'courses.detailPlaceholder':
         'Тут будуть відображатися інформація про дисципліну, додаткові матеріали та корисні посилання.',
@@ -1330,10 +1326,6 @@ const resources = {
       'courses.openMoodle': 'Open Moodle',
       'courses.moodleNoticeText':
         'Campus shows your courses, basic course information, additional materials, and online class links. Assignments and grading are managed separately in Moodle.',
-      'courses.detailsMoodleTitle':
-        'Assignments and grading are not duplicated in Campus',
-      'courses.detailsMoodleText':
-        'Use course materials for syllabi, programs, presentations, and useful HTTPS links. Open Moodle for assignments, work submission, and grades.',
       'courses.academicYear': 'Academic Year',
       'courses.detailPlaceholder':
         'Course information, additional materials, and useful links will be displayed here.',

--- a/client/src/i18n.ts
+++ b/client/src/i18n.ts
@@ -420,8 +420,6 @@ const resources = {
       'common.delete': 'Видалити',
 
       'news.title': 'Новини МАУП',
-      'news.subtitle':
-        'Останні матеріали з офіційної RSS-стрічки МАУП. Посилання відкриваються на сайті академії.',
       'news.source': 'Офіційна стрічка МАУП',
       'news.lastUpdated': 'Оновлено: {{date}}',
       'news.refresh': 'Оновити',
@@ -1482,8 +1480,6 @@ const resources = {
       'common.delete': 'Delete',
 
       'news.title': 'IAPM news',
-      'news.subtitle':
-        'Latest posts from the official IAPM RSS feed. Links open on the academy website.',
       'news.source': 'Official IAPM feed',
       'news.lastUpdated': 'Updated: {{date}}',
       'news.refresh': 'Refresh',

--- a/client/src/pages/admin/UsersPage.tsx
+++ b/client/src/pages/admin/UsersPage.tsx
@@ -120,12 +120,6 @@ export default function UsersPage() {
         )}
       </div>
 
-      {!canManageUsers && (
-        <div className="mb-6 rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-800">
-          {t('users.readOnlyDirectory')}
-        </div>
-      )}
-
       <div className="mb-6 rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
         <div className="flex flex-col gap-3 lg:flex-row">
           <div className="flex flex-1 flex-col gap-2 sm:flex-row">

--- a/client/src/pages/course/CourseDetailPage.tsx
+++ b/client/src/pages/course/CourseDetailPage.tsx
@@ -802,11 +802,6 @@ export default function CourseDetailPage() {
         </a>
       </div>
 
-      <div className="rounded-xl border border-blue-100 bg-blue-50 px-5 py-4 text-sm leading-6 text-blue-900">
-        <p className="font-semibold">{t("courses.detailsMoodleTitle")}</p>
-        <p className="mt-1 text-blue-800">{t("courses.detailsMoodleText")}</p>
-      </div>
-
       {statusMessage && (
         <div className="flex items-center justify-between rounded-lg border border-blue-100 bg-blue-50 px-4 py-3 text-sm text-blue-800">
           <span>{statusMessage}</span>

--- a/client/src/pages/shared/NewsPage.tsx
+++ b/client/src/pages/shared/NewsPage.tsx
@@ -96,9 +96,6 @@ export default function NewsPage() {
             <h1 className="mt-3 text-3xl font-bold tracking-tight">
               {t('news.title')}
             </h1>
-            <p className="mt-3 max-w-3xl text-sm leading-6 text-blue-50">
-              {t('news.subtitle')}
-            </p>
           </div>
 
           <button


### PR DESCRIPTION
<details>
<summary><strong>Українська версія</strong></summary>

## Підсумок

- Прибрано зайвий опис RSS-стрічки з hero-блоку сторінки новин.
- Прибрано інформаційний read-only notice зі сторінки користувачів.
- Прибрано пояснювальний Moodle notice зі сторінки деталей дисципліни.
- Видалено невикористані українські та англійські i18n-ключі для прибраного тексту.

## Перевірка

- `client`: `npm run lint:check`
- `client`: `npm run build`
- `git diff --check`

</details>

## Summary

- Removed the redundant RSS description from the News page hero.
- Removed the read-only informational notice from the Users page.
- Removed the Moodle explanatory notice from the Course detail page.
- Cleaned up unused Ukrainian and English i18n keys for the removed text.

## Validation

- `client`: `npm run lint:check`
- `client`: `npm run build`
- `git diff --check`